### PR TITLE
fix: ping/pong command + production readiness hardening

### DIFF
--- a/src/theswarm/cycle.py
+++ b/src/theswarm/cycle.py
@@ -184,130 +184,131 @@ async def run_daily_cycle(config: CycleConfig, on_progress=None) -> dict:
     await _ensure_workspace(config)
     base_state = _build_base_state(config)
 
-    # Ensure branch protection on first run
-    if config.is_real_mode and base_state.get("github"):
-        await _progress("System", "Checking branch protection…")
-        await base_state["github"].ensure_branch_protection()
+    try:
+        # Ensure branch protection on first run
+        if config.is_real_mode and base_state.get("github"):
+            await _progress("System", "Checking branch protection…")
+            await base_state["github"].ensure_branch_protection()
 
-    # --- MORNING: PO daily planning ---
-    await _progress("PO", "Starting daily planning…")
-    po = build_po_graph()
-    po_state = await po.ainvoke({**base_state, "phase": Phase.MORNING.value})
-    po_cost = po_state.get("cost_usd", 0.0)
-    tracker.record("po_morning", po_state.get("tokens_used", 0), po_cost)
-    total_cost += po_cost
-    _check_budget(Role.PO, po_state.get("tokens_used", 0))
+        # --- MORNING: PO daily planning ---
+        await _progress("PO", "Starting daily planning…")
+        po = build_po_graph()
+        po_state = await po.ainvoke({**base_state, "phase": Phase.MORNING.value})
+        po_cost = po_state.get("cost_usd", 0.0)
+        tracker.record("po_morning", po_state.get("tokens_used", 0), po_cost)
+        total_cost += po_cost
+        _check_budget(Role.PO, po_state.get("tokens_used", 0))
 
-    # --- MORNING: Tech Lead story breakdown ---
-    await _progress("TechLead", "Breaking down stories into tasks…")
-    tl = build_techlead_graph()
-    tl_state = await tl.ainvoke({**base_state, "phase": "breakdown"})
-    tl_bd_cost = tl_state.get("cost_usd", 0.0)
-    tracker.record("techlead_breakdown", tl_state.get("tokens_used", 0), tl_bd_cost)
-    total_cost += tl_bd_cost
-    _check_budget(Role.TECHLEAD, tl_state.get("tokens_used", 0))
+        # --- MORNING: Tech Lead story breakdown ---
+        await _progress("TechLead", "Breaking down stories into tasks…")
+        tl = build_techlead_graph()
+        tl_state = await tl.ainvoke({**base_state, "phase": "breakdown"})
+        tl_bd_cost = tl_state.get("cost_usd", 0.0)
+        tracker.record("techlead_breakdown", tl_state.get("tokens_used", 0), tl_bd_cost)
+        total_cost += tl_bd_cost
+        _check_budget(Role.TECHLEAD, tl_state.get("tokens_used", 0))
 
-    # --- DEVELOPMENT: Dev implements → TechLead reviews → repeat ---
-    await _progress("Dev", "Starting development loop…")
-    for iteration in range(1, MAX_DEV_ITERATIONS + 1):
-        await _progress("Dev", f"Iteration {iteration}/{MAX_DEV_ITERATIONS} — picking next task…")
-        dev = build_dev_graph()
-        dev_state = await dev.ainvoke({**base_state, "phase": Phase.DEVELOPMENT.value})
-        dev_cost = dev_state.get("cost_usd", 0.0)
-        dev_tokens = dev_state.get("tokens_used", 0)
-        tracker.record(f"dev_iter{iteration}", dev_tokens, dev_cost)
-        total_cost += dev_cost
-        _check_budget(Role.DEV, dev_tokens)
+        # --- DEVELOPMENT: Dev implements → TechLead reviews → repeat ---
+        await _progress("Dev", "Starting development loop…")
+        for iteration in range(1, MAX_DEV_ITERATIONS + 1):
+            await _progress("Dev", f"Iteration {iteration}/{MAX_DEV_ITERATIONS} — picking next task…")
+            dev = build_dev_graph()
+            dev_state = await dev.ainvoke({**base_state, "phase": Phase.DEVELOPMENT.value})
+            dev_cost = dev_state.get("cost_usd", 0.0)
+            dev_tokens = dev_state.get("tokens_used", 0)
+            tracker.record(f"dev_iter{iteration}", dev_tokens, dev_cost)
+            total_cost += dev_cost
+            _check_budget(Role.DEV, dev_tokens)
 
-        pr = dev_state.get("pr")
-        if pr:
-            all_prs.append(pr)
-            await _progress("Dev", f"PR #{pr['number']} opened: {pr['url']}")
-        else:
-            task = dev_state.get("task")
-            if task is None:
-                await _progress("Dev", "No more ready tasks — ending dev loop")
-                break
-            await _progress("Dev", f"No PR produced for task #{task['number']}")
+            pr = dev_state.get("pr")
+            if pr:
+                all_prs.append(pr)
+                await _progress("Dev", f"PR #{pr['number']} opened: {pr['url']}")
+            else:
+                task = dev_state.get("task")
+                if task is None:
+                    await _progress("Dev", "No more ready tasks — ending dev loop")
+                    break
+                await _progress("Dev", f"No PR produced for task #{task['number']}")
 
-        # TechLead reviews and merges
-        await _progress("TechLead", "Reviewing open PRs…")
-        tl_review = build_techlead_graph()
-        tl_state = await tl_review.ainvoke({**base_state, "phase": "review_loop"})
-        tl_cost = tl_state.get("cost_usd", 0.0)
-        tl_tokens = tl_state.get("tokens_used", 0)
-        tracker.record(f"techlead_review_iter{iteration}", tl_tokens, tl_cost)
-        total_cost += tl_cost
-        _check_budget(Role.TECHLEAD, tl_tokens)
+            # TechLead reviews and merges
+            await _progress("TechLead", "Reviewing open PRs…")
+            tl_review = build_techlead_graph()
+            tl_state = await tl_review.ainvoke({**base_state, "phase": "review_loop"})
+            tl_cost = tl_state.get("cost_usd", 0.0)
+            tl_tokens = tl_state.get("tokens_used", 0)
+            tracker.record(f"techlead_review_iter{iteration}", tl_tokens, tl_cost)
+            total_cost += tl_cost
+            _check_budget(Role.TECHLEAD, tl_tokens)
 
-        reviews = tl_state.get("reviews", [])
-        all_reviews.extend(reviews)
-        merged = tl_state.get("merged_prs", [])
-        for r in reviews:
-            await _progress("TechLead", f"PR #{r['pr_number']}: {r['decision']}")
-        if merged:
-            await _progress("TechLead", f"Merged: {merged}")
+            reviews = tl_state.get("reviews", [])
+            all_reviews.extend(reviews)
+            merged = tl_state.get("merged_prs", [])
+            for r in reviews:
+                await _progress("TechLead", f"PR #{r['pr_number']}: {r['decision']}")
+            if merged:
+                await _progress("TechLead", f"Merged: {merged}")
 
-        # Pull latest into workspace so next iteration builds on merged code
-        if merged:
-            await _pull_latest(config)
+            # Pull latest into workspace so next iteration builds on merged code
+            if merged:
+                await _pull_latest(config)
 
-    # --- DEMO: QA generates demo ---
-    await _progress("QA", "Running tests + security scan…")
-    qa = build_qa_graph()
-    qa_state = await qa.ainvoke({**base_state, "phase": Phase.DEMO.value})
-    qa_cost = qa_state.get("cost_usd", 0.0)
-    tracker.record("qa", qa_state.get("tokens_used", 0), qa_cost)
-    total_cost += qa_cost
-    _check_budget(Role.QA, qa_state.get("tokens_used", 0))
+        # --- DEMO: QA generates demo ---
+        await _progress("QA", "Running tests + security scan…")
+        qa = build_qa_graph()
+        qa_state = await qa.ainvoke({**base_state, "phase": Phase.DEMO.value})
+        qa_cost = qa_state.get("cost_usd", 0.0)
+        tracker.record("qa", qa_state.get("tokens_used", 0), qa_cost)
+        total_cost += qa_cost
+        _check_budget(Role.QA, qa_state.get("tokens_used", 0))
 
-    # --- EVENING: PO validates + reports ---
-    await _progress("PO", "Generating daily report…")
-    po_evening = build_po_graph()
-    po_ev_state = await po_evening.ainvoke({
-        **base_state,
-        "phase": Phase.EVENING.value,
-        "demo_report": qa_state.get("demo_report"),
-    })
-    po_ev_cost = po_ev_state.get("cost_usd", 0.0)
-    tracker.record("po_evening", po_ev_state.get("tokens_used", 0), po_ev_cost)
-    total_cost += po_ev_cost
+        # --- EVENING: PO validates + reports ---
+        await _progress("PO", "Generating daily report…")
+        po_evening = build_po_graph()
+        po_ev_state = await po_evening.ainvoke({
+            **base_state,
+            "phase": Phase.EVENING.value,
+            "demo_report": qa_state.get("demo_report"),
+        })
+        po_ev_cost = po_ev_state.get("cost_usd", 0.0)
+        tracker.record("po_evening", po_ev_state.get("tokens_used", 0), po_ev_cost)
+        total_cost += po_ev_cost
 
-    # --- SUMMARY ---
-    print(f"\n{'=' * 60}")
-    print("CYCLE COMPLETE")
-    print(f"{'=' * 60}")
-    tracker.print_summary()
-    print(f"\nClaude API cost: ${total_cost:.2f}")
-    print(f"PRs opened: {len(all_prs)}")
-    print(f"PRs merged: {sum(1 for r in all_reviews if r.get('decision') == 'APPROVE')}")
+        # --- SUMMARY ---
+        print(f"\n{'=' * 60}")
+        print("CYCLE COMPLETE")
+        print(f"{'=' * 60}")
+        tracker.print_summary()
+        print(f"\nClaude API cost: ${total_cost:.2f}")
+        print(f"PRs opened: {len(all_prs)}")
+        print(f"PRs merged: {sum(1 for r in all_reviews if r.get('decision') == 'APPROVE')}")
 
-    await _progress("PO", "Cycle complete!")
+        await _progress("PO", "Cycle complete!")
 
-    result = {
-        "date": today,
-        "tokens": tracker.total_tokens,
-        "cost_usd": total_cost,
-        "prs": all_prs,
-        "reviews": all_reviews,
-        "demo_report": qa_state.get("demo_report"),
-        "daily_report": po_ev_state.get("daily_report", ""),
-    }
+        result = {
+            "date": today,
+            "tokens": tracker.total_tokens,
+            "cost_usd": total_cost,
+            "prs": all_prs,
+            "reviews": all_reviews,
+            "demo_report": qa_state.get("demo_report"),
+            "daily_report": po_ev_state.get("daily_report", ""),
+        }
 
-    # --- MEMORY: retrospective + learnings ---
-    if config.is_real_mode:
-        await _write_cycle_learnings(base_state, result, _progress)
+        # --- MEMORY: retrospective + learnings ---
+        if config.is_real_mode:
+            await _write_cycle_learnings(base_state, result, _progress)
 
-    # --- PERSIST: write cycle history ---
-    from theswarm.cycle_log import append_cycle_log
-    await append_cycle_log(config, result)
+        # --- PERSIST: write cycle history ---
+        from theswarm.cycle_log import append_cycle_log
+        await append_cycle_log(config, result)
 
-    # --- CLEANUP: remove workspace ---
-    if config.is_real_mode:
-        from theswarm.tools.git import cleanup_workspace
-        await cleanup_workspace(config.workspace_dir)
-
-    return result
+        return result
+    finally:
+        # Cleanup workspace even on failure
+        if config.is_real_mode:
+            from theswarm.tools.git import cleanup_workspace
+            await cleanup_workspace(config.workspace_dir)
 
 
 async def run_dev_only(config: CycleConfig) -> dict:

--- a/src/theswarm/gateway/app.py
+++ b/src/theswarm/gateway/app.py
@@ -63,12 +63,19 @@ class SwarmGateway:
                 if self._swarm_po_cycle_running:
                     swarm_po_status = f"running (phase: {self._swarm_po_current_phase})"
             vcs_map = getattr(self, "_swarm_po_vcs_map", {})
+            has_github = bool(getattr(self, "_swarm_po_github", None))
+            has_chat = bool(self._swarm_po_chat)
+            overall = "ok" if (has_github and has_chat) else "degraded"
             return {
-                "status": "ok",
+                "status": overall,
                 "service": "theswarm",
                 "bots": {"swarm_po": swarm_po_status},
                 "repos": list(vcs_map.keys()),
                 "default_repo": getattr(self, "_swarm_po_default_repo", ""),
+                "checks": {
+                    "github": "connected" if has_github else "missing",
+                    "chat": "connected" if has_chat else "missing",
+                },
             }
 
     def register(self, event_type: str, handler) -> None:

--- a/src/theswarm/gateway/wiring.py
+++ b/src/theswarm/gateway/wiring.py
@@ -43,6 +43,16 @@ def wire_swarm_po(gw: SwarmGateway, vcs_map: dict, default_repo: str, chat, team
         action_type = parts[0]
         pending_id = parts[1]
 
+        # Ping/pong callback — no pending stories needed
+        if action_type == "swarm_po_pong":
+            user_id = event.payload.get("user_id", "")
+            if chat and user_id:
+                await chat.post_dm(user_id, "🏓 Pong!")
+            return
+
+        if action_type == "swarm_po_dismiss":
+            return  # silently dismiss
+
         pending = gw._swarm_po_pending_stories.pop(pending_id, None)
         if not pending:
             log.warning("SwarmPO: no pending stories for id=%s", pending_id)

--- a/src/theswarm/main.py
+++ b/src/theswarm/main.py
@@ -189,8 +189,23 @@ async def _connect_mattermost(config: MattermostConfig, server_config=None, labe
 # ── Start ─────────────────────────────────────────────────────────────
 
 
+def _validate_env() -> list[str]:
+    """Check required env vars and return a list of warnings (empty = all good)."""
+    warnings: list[str] = []
+    if not os.getenv("GITHUB_TOKEN"):
+        warnings.append("GITHUB_TOKEN is not set — GitHub operations will fail")
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        warnings.append("ANTHROPIC_API_KEY is not set — agent cycles will fail")
+    return warnings
+
+
 async def start() -> None:
     settings = load_swarm_settings()
+
+    # Pre-flight env var check
+    env_warnings = _validate_env()
+    for w in env_warnings:
+        log.warning("ENV: %s", w)
 
     from theswarm.gateway import SwarmGateway
 
@@ -258,11 +273,12 @@ async def start() -> None:
             return JSONResponse(status_code=403, content={"error": "forbidden"})
 
         post_id = body.get("post_id", "")
+        user_id = body.get("user_id", "")
         action_id = context.get("action_id", "") or body.get("action", "")
         agent_event = AgentEvent(
             event_type="chat_action",
             source="mattermost",
-            payload={"action_id": action_id, "post_id": post_id, "context": context},
+            payload={"action_id": action_id, "post_id": post_id, "user_id": user_id, "context": context},
         )
         await gw.route_event(agent_event)
         return {"update": {"message": "Action received."}}

--- a/src/theswarm/persona.py
+++ b/src/theswarm/persona.py
@@ -24,6 +24,7 @@ KNOWN_ACTIONS = [
     "show_report",
     "list_stories",
     "list_repos",
+    "ping",
     "help",
 ]
 
@@ -120,6 +121,9 @@ async def handle_dm(
     elif intent.action == "list_repos":
         await _handle_list_repos(user_id, chat, gateway)
 
+    elif intent.action == "ping":
+        await _handle_ping(user_id, chat)
+
 
 # ── Intent handlers ────────────────────────────────────────────────────────
 
@@ -208,6 +212,18 @@ async def _handle_list_repos(user_id: str, chat, gateway) -> None:
         default = " _(default)_" if repo == default_repo else ""
         lines.append(f"• `{repo}`{default}")
     await chat.post_dm(user_id, "\n".join(lines))
+
+
+async def _handle_ping(user_id: str, chat) -> None:
+    """Respond with interactive buttons to verify the callback flow works."""
+    await chat.post_dm_interactive(
+        user_id,
+        "🏓 Ping!",
+        actions=[
+            {"id": "swarm_po_pong:ping", "name": "Pong", "style": "good"},
+            {"id": "swarm_po_dismiss:ping", "name": "Dismiss", "style": "default"},
+        ],
+    )
 
 
 async def _handle_list_stories(user_id: str, chat, gateway) -> None:

--- a/tests/test_gateway_app.py
+++ b/tests/test_gateway_app.py
@@ -49,7 +49,7 @@ async def test_health_disabled(gateway):
         resp = await client.get("/health")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["status"] == "ok"
+    assert data["status"] == "degraded"
     assert data["bots"]["swarm_po"] == "disabled"
 
 

--- a/tests/test_ping_pong.py
+++ b/tests/test_ping_pong.py
@@ -1,0 +1,156 @@
+"""Tests for the ping/pong interactive button flow.
+
+Covers:
+1. Ping intent → interactive buttons posted
+2. Pong callback → "Pong!" posted to DM
+3. Dismiss callback → no response
+4. Full flow: DM → NLU → handler → buttons → callback → response
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from theswarm_common.chat import Intent
+from theswarm_common.models import AgentEvent
+
+
+# ── Ping handler ─────────────────────────────────────────────────
+
+
+async def test_ping_posts_interactive_buttons():
+    """Sending 'ping' DM posts a message with Pong and Dismiss buttons."""
+    from theswarm.persona import handle_dm
+
+    chat = AsyncMock()
+    chat.post_dm_interactive = AsyncMock(return_value="post123")
+
+    nlu = AsyncMock()
+    nlu.parse_intent = AsyncMock(return_value=Intent(
+        action="ping", params={}, confidence=0.95, raw_text="ping",
+    ))
+
+    gateway = MagicMock()
+
+    await handle_dm("ping", "user1", chat, nlu, gateway)
+
+    chat.post_dm_interactive.assert_called_once()
+    call_args = chat.post_dm_interactive.call_args
+    assert call_args[0][0] == "user1"  # user_id
+    assert "Ping" in call_args[0][1]  # text contains Ping
+
+    actions = call_args.kwargs.get("actions") or call_args[0][2]
+    assert len(actions) == 2
+    assert actions[0]["name"] == "Pong"
+    assert actions[0]["id"].startswith("swarm_po_pong:")
+    assert actions[1]["name"] == "Dismiss"
+
+
+async def test_ping_is_in_known_actions():
+    """'ping' must be in KNOWN_ACTIONS for NLU to route to it."""
+    from theswarm.persona import KNOWN_ACTIONS
+    assert "ping" in KNOWN_ACTIONS
+
+
+# ── Pong callback ────────────────────────────────────────────────
+
+
+async def test_pong_callback_posts_pong(gateway):
+    """Clicking the Pong button posts 'Pong!' to the user's DM."""
+    from theswarm.gateway.wiring import wire_swarm_po
+
+    chat = AsyncMock()
+    team_chat = AsyncMock()
+    vcs_map = {"owner/repo": MagicMock()}
+
+    wire_swarm_po(gateway, vcs_map, "owner/repo", chat, team_chat)
+
+    # Simulate Mattermost callback for pong button
+    event = AgentEvent(
+        event_type="chat_action",
+        source="mattermost",
+        payload={
+            "action_id": "swarm_po_pong:ping",
+            "post_id": "post123",
+            "user_id": "user1",
+            "context": {"action_id": "swarm_po_pong:ping"},
+        },
+    )
+    await gateway.route_event(event)
+
+    chat.post_dm.assert_called_once_with("user1", "🏓 Pong!")
+
+
+async def test_dismiss_callback_is_silent(gateway):
+    """Clicking the Dismiss button does nothing."""
+    from theswarm.gateway.wiring import wire_swarm_po
+
+    chat = AsyncMock()
+    team_chat = AsyncMock()
+    vcs_map = {"owner/repo": MagicMock()}
+
+    wire_swarm_po(gateway, vcs_map, "owner/repo", chat, team_chat)
+
+    event = AgentEvent(
+        event_type="chat_action",
+        source="mattermost",
+        payload={
+            "action_id": "swarm_po_dismiss:ping",
+            "post_id": "post123",
+            "user_id": "user1",
+            "context": {"action_id": "swarm_po_dismiss:ping"},
+        },
+    )
+    await gateway.route_event(event)
+
+    chat.post_dm.assert_not_called()
+
+
+# ── Full flow ────────────────────────────────────────────────────
+
+
+async def test_full_ping_pong_flow(gateway):
+    """Full flow: ping DM → interactive buttons → pong callback → response."""
+    from theswarm.gateway.wiring import wire_swarm_po
+    from theswarm.persona import handle_dm
+
+    chat = AsyncMock()
+    chat.post_dm_interactive = AsyncMock(return_value="post123")
+    team_chat = AsyncMock()
+    vcs_map = {"owner/repo": MagicMock()}
+
+    wire_swarm_po(gateway, vcs_map, "owner/repo", chat, team_chat)
+
+    nlu = AsyncMock()
+    nlu.parse_intent = AsyncMock(return_value=Intent(
+        action="ping", params={}, confidence=0.95, raw_text="ping",
+    ))
+    gateway._nlu = nlu
+
+    # Step 1: User sends "ping" DM
+    await handle_dm("ping", "user1", chat, nlu, gateway)
+
+    # Verify buttons were posted
+    assert chat.post_dm_interactive.call_count == 1
+    call_args = chat.post_dm_interactive.call_args
+    actions = call_args.kwargs.get("actions") or call_args[0][2]
+    pong_action_id = actions[0]["id"]
+    assert pong_action_id.startswith("swarm_po_pong:")
+
+    # Step 2: User clicks Pong button → Mattermost sends callback
+    event = AgentEvent(
+        event_type="chat_action",
+        source="mattermost",
+        payload={
+            "action_id": pong_action_id,
+            "post_id": "post123",
+            "user_id": "user1",
+            "context": {"action_id": pong_action_id},
+        },
+    )
+    await gateway.route_event(event)
+
+    # Step 3: Verify "Pong!" was posted
+    chat.post_dm.assert_called_once_with("user1", "🏓 Pong!")


### PR DESCRIPTION
## Summary

- **P0 fix**: Implement the ping/pong interactive button command (was never built, not just broken)
- **Workspace cleanup**: Now runs in `finally` block so mid-cycle failures don't leave cloned repos on disk
- **Health endpoint**: Returns `"degraded"` when GitHub or chat are disconnected instead of always `"ok"`
- **Env var validation**: Warns at startup if `GITHUB_TOKEN` or `ANTHROPIC_API_KEY` are missing
- **Callback fix**: `user_id` now passed through Mattermost callback payload

## Test plan

- [x] 5 new ping/pong tests covering full callback chain
- [x] Updated health endpoint test for degraded status
- [x] 449 tests passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)