### PR TITLE
fix: route !ping through NLU + Ping/Pong buttons

### DIFF
--- a/src/theswarm/gateway/wiring.py
+++ b/src/theswarm/gateway/wiring.py
@@ -44,10 +44,16 @@ def wire_swarm_po(gw: SwarmGateway, vcs_map: dict, default_repo: str, chat, team
         pending_id = parts[1]
 
         # Ping/pong callback — no pending stories needed
+        if action_type == "swarm_po_ping":
+            user_id = event.payload.get("user_id", "")
+            if chat and user_id:
+                await chat.post_dm(user_id, "ping")
+            return
+
         if action_type == "swarm_po_pong":
             user_id = event.payload.get("user_id", "")
             if chat and user_id:
-                await chat.post_dm(user_id, "🏓 Pong!")
+                await chat.post_dm(user_id, "pong")
             return
 
         if action_type == "swarm_po_dismiss":

--- a/src/theswarm/main.py
+++ b/src/theswarm/main.py
@@ -356,6 +356,7 @@ class _KeywordNLU:
         msg = message.lower().strip()
 
         keywords = {
+            "ping": "ping",
             "help": "help",
             "aide": "help",
             "status": "show_status",

--- a/src/theswarm/persona.py
+++ b/src/theswarm/persona.py
@@ -218,10 +218,10 @@ async def _handle_ping(user_id: str, chat) -> None:
     """Respond with interactive buttons to verify the callback flow works."""
     await chat.post_dm_interactive(
         user_id,
-        "🏓 Ping!",
+        "🏓 Choose a button:",
         actions=[
+            {"id": "swarm_po_ping:ping", "name": "Ping", "style": "default"},
             {"id": "swarm_po_pong:ping", "name": "Pong", "style": "good"},
-            {"id": "swarm_po_dismiss:ping", "name": "Dismiss", "style": "default"},
         ],
     )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -101,6 +101,15 @@ async def test_keyword_nlu_help(keyword_nlu):
     assert intent.action == "help"
 
 
+async def test_keyword_nlu_ping(keyword_nlu):
+    """!ping must route to the ping action, not 'unknown'."""
+    intent = await keyword_nlu.parse_intent("!ping", "swarm_po", [])
+    assert intent.action == "ping"
+
+    intent = await keyword_nlu.parse_intent("ping", "swarm_po", [])
+    assert intent.action == "ping"
+
+
 async def test_keyword_nlu_status(keyword_nlu):
     intent = await keyword_nlu.parse_intent("status", "swarm_po", [])
     assert intent.action == "show_status"

--- a/tests/test_ping_pong.py
+++ b/tests/test_ping_pong.py
@@ -39,13 +39,14 @@ async def test_ping_posts_interactive_buttons():
     chat.post_dm_interactive.assert_called_once()
     call_args = chat.post_dm_interactive.call_args
     assert call_args[0][0] == "user1"  # user_id
-    assert "Ping" in call_args[0][1]  # text contains Ping
+    assert call_args[0][1]  # has some text
 
     actions = call_args.kwargs.get("actions") or call_args[0][2]
     assert len(actions) == 2
-    assert actions[0]["name"] == "Pong"
-    assert actions[0]["id"].startswith("swarm_po_pong:")
-    assert actions[1]["name"] == "Dismiss"
+    assert actions[0]["name"] == "Ping"
+    assert actions[0]["id"].startswith("swarm_po_ping:")
+    assert actions[1]["name"] == "Pong"
+    assert actions[1]["id"].startswith("swarm_po_pong:")
 
 
 async def test_ping_is_in_known_actions():
@@ -58,7 +59,7 @@ async def test_ping_is_in_known_actions():
 
 
 async def test_pong_callback_posts_pong(gateway):
-    """Clicking the Pong button posts 'Pong!' to the user's DM."""
+    """Clicking the Pong button posts 'pong' to the user's DM."""
     from theswarm.gateway.wiring import wire_swarm_po
 
     chat = AsyncMock()
@@ -80,7 +81,32 @@ async def test_pong_callback_posts_pong(gateway):
     )
     await gateway.route_event(event)
 
-    chat.post_dm.assert_called_once_with("user1", "🏓 Pong!")
+    chat.post_dm.assert_called_once_with("user1", "pong")
+
+
+async def test_ping_callback_posts_ping(gateway):
+    """Clicking the Ping button posts 'ping' to the user's DM."""
+    from theswarm.gateway.wiring import wire_swarm_po
+
+    chat = AsyncMock()
+    team_chat = AsyncMock()
+    vcs_map = {"owner/repo": MagicMock()}
+
+    wire_swarm_po(gateway, vcs_map, "owner/repo", chat, team_chat)
+
+    event = AgentEvent(
+        event_type="chat_action",
+        source="mattermost",
+        payload={
+            "action_id": "swarm_po_ping:ping",
+            "post_id": "post123",
+            "user_id": "user1",
+            "context": {"action_id": "swarm_po_ping:ping"},
+        },
+    )
+    await gateway.route_event(event)
+
+    chat.post_dm.assert_called_once_with("user1", "ping")
 
 
 async def test_dismiss_callback_is_silent(gateway):
@@ -136,7 +162,7 @@ async def test_full_ping_pong_flow(gateway):
     assert chat.post_dm_interactive.call_count == 1
     call_args = chat.post_dm_interactive.call_args
     actions = call_args.kwargs.get("actions") or call_args[0][2]
-    pong_action_id = actions[0]["id"]
+    pong_action_id = actions[1]["id"]
     assert pong_action_id.startswith("swarm_po_pong:")
 
     # Step 2: User clicks Pong button → Mattermost sends callback
@@ -152,5 +178,5 @@ async def test_full_ping_pong_flow(gateway):
     )
     await gateway.route_event(event)
 
-    # Step 3: Verify "Pong!" was posted
-    chat.post_dm.assert_called_once_with("user1", "🏓 Pong!")
+    # Step 3: Verify "pong" was posted
+    chat.post_dm.assert_called_once_with("user1", "pong")


### PR DESCRIPTION
## The actual bug

PR #2 added the persona handler and callback wiring, but the KeywordNLU in main.py had no "ping" entry. So "!ping" fell through to the substring loop, didn't match any keyword, was 5 chars (< 10), and returned `unknown` → "Je n'ai pas compris".

That's exactly what the user saw in production.

## Fix

- Add `"ping": "ping"` to the KeywordNLU keyword map
- Change buttons from Pong/Dismiss to Ping/Pong (per user spec)
- Click Ping → bot posts "ping"
- Click Pong → bot posts "pong"
- Add NLU keyword test + Ping callback test

## Test plan

- [x] `test_keyword_nlu_ping` covers both `!ping` and `ping`
- [x] `test_ping_callback_posts_ping` covers the Ping button
- [x] `test_pong_callback_posts_pong` updated for new "pong" message
- [x] 450 tests passing