### PR TITLE
fix(sidebar): compensate Pico negative nav margins, restore icons, separate hamburger/logo hit targets

### DIFF
--- a/src/theswarm/presentation/web/static/css/dashboard.css
+++ b/src/theswarm/presentation/web/static/css/dashboard.css
@@ -80,7 +80,10 @@ html[data-sidebar="collapsed"] body {
   height: 100vh;
   background: var(--sidebar-bg);
   border-right: 1px solid var(--border);
-  padding: 1rem 0.6rem 0.6rem;
+  /* Top padding clears the fixed hamburger toggle (0.5rem offset + 2rem
+   * button) so the logo link never sits under it — overlapping hit targets
+   * made taps near the toggle navigate to "/" instead of toggling. */
+  padding: 2.75rem 0.6rem 0.6rem;
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
@@ -189,8 +192,14 @@ html[data-sidebar="collapsed"] .sidebar-resize-handle { display: none; }
 .sidebar-nav summary:hover { color: var(--text-primary); }
 
 /* Override Pico's `nav ul { display:flex; align-items:center }`
- * and `nav li { display:inline-block }`. */
-.sidebar-nav ul {
+ * and `nav li { display:inline-block }`. The :first-of-type/:last-of-type
+ * co-selectors are needed to outrank Pico's
+ * `nav ul:first-of-type { margin-left: calc(spacing * -1) }` (0-1-2),
+ * which otherwise beats a bare `.sidebar-nav ul` (0-1-1) and drags the
+ * list off the left edge — clipping the first characters of every label. */
+.sidebar-nav ul,
+.sidebar-nav ul:first-of-type,
+.sidebar-nav ul:last-of-type {
   list-style: none;
   padding: 0 0 0.25rem;
   margin: 0;
@@ -205,8 +214,13 @@ html[data-sidebar="collapsed"] .sidebar-resize-handle { display: none; }
   margin: 0;
 }
 .sidebar-nav a {
-  display: block;
-  padding: 0.4rem 0.75rem 0.4rem 1.4rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  /* Pico's `nav li :where(a)` applies negative margins to pull links flush
+   * with the nav edge; reset them or labels get clipped. */
+  margin: 0;
+  padding: 0.4rem 0.75rem;
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   text-decoration: none;
@@ -217,15 +231,27 @@ html[data-sidebar="collapsed"] .sidebar-resize-handle { display: none; }
   text-overflow: ellipsis;
   transition: background 100ms ease, color 100ms ease;
 }
+.sidebar-nav a::before {
+  content: attr(data-icon);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
 .sidebar-nav a:hover {
   background: var(--bg-secondary);
   color: var(--text-primary);
   text-decoration: none;
 }
+.sidebar-nav a:hover::before { color: var(--accent); }
 .sidebar-nav a[aria-current="page"] {
   background: var(--accent-subtle);
   color: var(--accent);
 }
+.sidebar-nav a[aria-current="page"]::before { color: var(--accent); }
 .sidebar-footer {
   border-top: 1px solid var(--border);
   padding: 0.6rem 0.5rem 0.4rem;
@@ -316,7 +342,9 @@ html[data-sidebar="collapsed"] .sidebar-logo {
   }
   html[data-sidebar="expanded"] .sidebar {
     position: fixed;
-    width: var(--sidebar-width);
+    /* Cap the drawer so it never covers the whole viewport, even if the
+     * user widened the sidebar on desktop (width is persisted). */
+    width: min(var(--sidebar-width), 82vw);
     box-shadow: 0 0 30px rgba(0,0,0,0.6);
   }
   html[data-sidebar="expanded"] body { grid-template-columns: 0 1fr; }

--- a/src/theswarm/presentation/web/templates/base.html
+++ b/src/theswarm/presentation/web/templates/base.html
@@ -29,53 +29,53 @@
       <details open>
         <summary>Workspace</summary>
         <ul>
-          <li><a href="{{ base }}/">Dashboard</a></li>
-          <li><a href="{{ base }}/projects/">Projects</a></li>
-          <li><a href="{{ base }}/team">Team</a></li>
+          <li><a href="{{ base }}/" data-icon="◇"><span>Dashboard</span></a></li>
+          <li><a href="{{ base }}/projects/" data-icon="▤"><span>Projects</span></a></li>
+          <li><a href="{{ base }}/team" data-icon="◉"><span>Team</span></a></li>
         </ul>
       </details>
 
       <details open>
         <summary>Activity</summary>
         <ul>
-          <li><a href="{{ base }}/cycles/">Cycles</a></li>
-          <li><a href="{{ base }}/chat">Chat</a></li>
-          <li><a href="{{ base }}/proposals">Proposals</a></li>
+          <li><a href="{{ base }}/cycles/" data-icon="↻"><span>Cycles</span></a></li>
+          <li><a href="{{ base }}/chat" data-icon="✉"><span>Chat</span></a></li>
+          <li><a href="{{ base }}/proposals" data-icon="✦"><span>Proposals</span></a></li>
         </ul>
       </details>
 
       <details open>
         <summary>Output</summary>
         <ul>
-          <li><a href="{{ base }}/reports/">Reports</a></li>
-          <li><a href="{{ base }}/demos/">Demos</a></li>
-          <li><a href="{{ base }}/features/">Features</a></li>
+          <li><a href="{{ base }}/reports/" data-icon="▦"><span>Reports</span></a></li>
+          <li><a href="{{ base }}/demos/" data-icon="▶"><span>Demos</span></a></li>
+          <li><a href="{{ base }}/features/" data-icon="★"><span>Features</span></a></li>
         </ul>
       </details>
 
       <details>
         <summary>Roles</summary>
         <ul>
-          <li><a href="{{ base }}/architect/paved-road">Architect</a></li>
-          <li><a href="{{ base }}/chief-of-staff/routing">Chief of Staff</a></li>
-          <li><a href="{{ base }}/intel/feed">Scout</a></li>
+          <li><a href="{{ base }}/architect/paved-road" data-icon="△"><span>Architect</span></a></li>
+          <li><a href="{{ base }}/chief-of-staff/routing" data-icon="◈"><span>Chief of Staff</span></a></li>
+          <li><a href="{{ base }}/intel/feed" data-icon="◎"><span>Scout</span></a></li>
         </ul>
       </details>
 
       <details>
         <summary>Knowledge</summary>
         <ul>
-          <li><a href="{{ base }}/semantic-memory">Memory</a></li>
-          <li><a href="{{ base }}/prompt-library">Prompts</a></li>
-          <li><a href="{{ base }}/refactor-programs">Refactors</a></li>
+          <li><a href="{{ base }}/semantic-memory" data-icon="❖"><span>Memory</span></a></li>
+          <li><a href="{{ base }}/prompt-library" data-icon="❡"><span>Prompts</span></a></li>
+          <li><a href="{{ base }}/refactor-programs" data-icon="⟲"><span>Refactors</span></a></li>
         </ul>
       </details>
 
       <details open>
         <summary>System</summary>
         <ul>
-          <li><a href="{{ base }}/settings">Settings</a></li>
-          <li><a href="{{ base }}/health/ready/page">Health</a></li>
+          <li><a href="{{ base }}/settings" data-icon="⚙"><span>Settings</span></a></li>
+          <li><a href="{{ base }}/health/ready/page" data-icon="♥"><span>Health</span></a></li>
         </ul>
       </details>
     </nav>


### PR DESCRIPTION
## Summary

Fixes three sidebar regressions introduced by the details/summary refactor (d618a98, 42edc72):

- **Labels clipped on the left** ("Cycles" → "ycles", "Chat" → "hat", …): Pico's `nav ul:first-of-type { margin-left: calc(spacing * -1) }` (specificity 0-1-2) outranks our `.sidebar-nav ul` reset (0-1-1), and `nav li :where(a)` applies negative margins on links that were never reset. Fixed with `:first-of-type`/`:last-of-type` co-selectors and `margin: 0` on nav links.
- **Nav icons gone**: restored the `data-icon` attributes and `::before` glyph rendering so the sidebar matches the tour captures (static/demos/tour).
- **Mobile hit targets**: the fixed hamburger overlapped the logo link (`href="/"`), so taps near it navigated to Dashboard instead of toggling the drawer. Sidebar content now clears the toggle (padding-top 2.75rem) and the drawer is capped at 82vw.

## Test plan

- [x] 450 presentation + GA-smoke tests pass locally
- [x] Verified in browser at 375×812, 768×1024, 1280×720, 1440×900: labels complete, icons rendered, active-link highlight intact
- [x] Mobile: hamburger tap collapses the drawer (no more accidental navigation), drawer no longer covers the full viewport
- [ ] Re-verify on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)