### PR TITLE
fix(cycle): address the three April prod failure modes on concert-tour-app

### DIFF
--- a/src/theswarm/api.py
+++ b/src/theswarm/api.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import uuid
 from datetime import datetime
 from enum import Enum
@@ -17,6 +18,12 @@ from typing import Any
 from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
+
+# Whole-cycle hard timeout. Per-phase timeouts in cycle.py cover normal
+# operation; this is the backstop for hangs outside phase scopes (workspace
+# clone, retrospective, anything awaiting without its own timeout). Sized
+# above the worst-case sum of phase budgets (~2h20).
+CYCLE_HARD_TIMEOUT_SECONDS = int(os.environ.get("SWARM_CYCLE_TIMEOUT", str(3 * 3600)))
 
 
 class CycleStatus(str, Enum):
@@ -345,12 +352,20 @@ async def run_api_cycle(
                 except Exception:
                     log.exception("checkpoint save failed for cycle %s phase %s", cycle_id, phase)
 
-        result = await run_daily_cycle(
-            cycle_config,
-            on_progress=on_progress,
-            on_checkpoint=on_checkpoint,
-            resume_from=resume_from,
-        )
+        try:
+            result = await asyncio.wait_for(
+                run_daily_cycle(
+                    cycle_config,
+                    on_progress=on_progress,
+                    on_checkpoint=on_checkpoint,
+                    resume_from=resume_from,
+                ),
+                timeout=CYCLE_HARD_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            raise RuntimeError(
+                f"cycle exceeded hard timeout ({CYCLE_HARD_TIMEOUT_SECONDS}s) — aborted"
+            ) from None
 
         dash.cost_so_far = result.get("cost_usd", 0.0)
         cycle_date = result.get("date", "")

--- a/src/theswarm/application/services/orphan_reaper.py
+++ b/src/theswarm/application/services/orphan_reaper.py
@@ -1,0 +1,45 @@
+"""Periodic reaper for cycles stuck in 'running' state.
+
+The startup-only reap in server.py handles rows orphaned by a container
+restart. This loop covers the other case seen in prod (April 2026,
+concert-tour-app): the process keeps running but a cycle hangs in a spot
+without its own timeout, so its row stays 'running' for days until the
+next deploy. The loop concludes such rows within one interval once they
+exceed the whole-cycle hard timeout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Protocol
+
+log = logging.getLogger(__name__)
+
+DEFAULT_REAP_INTERVAL_SECONDS = 15 * 60
+
+
+class CycleReaperPort(Protocol):
+    async def reap_orphans(self, *, max_age_seconds: int) -> int: ...
+
+
+async def run_orphan_reap_loop(
+    cycle_repo: CycleReaperPort,
+    *,
+    max_age_seconds: int,
+    interval_seconds: float = DEFAULT_REAP_INTERVAL_SECONDS,
+) -> None:
+    """Reap stale 'running' cycles every ``interval_seconds``, forever.
+
+    ``max_age_seconds`` must exceed the whole-cycle hard timeout so a
+    legitimately running cycle is never reaped from under its task.
+    Repo errors are logged and the loop continues.
+    """
+    while True:
+        await asyncio.sleep(interval_seconds)
+        try:
+            n = await cycle_repo.reap_orphans(max_age_seconds=max_age_seconds)
+            if n:
+                log.info("Periodic reap: %d stale running cycle(s) marked failed", n)
+        except Exception:
+            log.exception("Periodic orphan reap failed (loop continues)")

--- a/src/theswarm/cycle.py
+++ b/src/theswarm/cycle.py
@@ -12,6 +12,7 @@ from theswarm.agents.qa import build_qa_graph
 from theswarm.agents.techlead import build_techlead_graph
 from theswarm.config import CycleConfig, Phase, Role
 from theswarm.token_counter import TokenTracker
+from theswarm.tools.claude import ClaudeFatalError
 
 log = logging.getLogger(__name__)
 
@@ -326,6 +327,10 @@ async def run_daily_cycle(
             except PhaseTimeout:
                 await _progress("Dev", f"Iteration {iteration} timed out — moving on")
                 continue
+            except ClaudeFatalError as exc:
+                # Billing/auth error — every later call would fail identically.
+                await _progress("Dev", f"Fatal Claude error — aborting cycle: {str(exc)[:160]}")
+                raise
             except Exception as exc:
                 msg = f"{type(exc).__name__}: {str(exc)[:160]}"
                 await _progress("Dev", f"Iteration {iteration} failed ({msg}) — retrying once")
@@ -340,6 +345,9 @@ async def run_daily_cycle(
                 except PhaseTimeout:
                     await _progress("Dev", f"Iteration {iteration} retry timed out — moving on")
                     continue
+                except ClaudeFatalError as exc2:
+                    await _progress("Dev", f"Fatal Claude error — aborting cycle: {str(exc2)[:160]}")
+                    raise
                 except Exception as exc2:
                     msg2 = f"{type(exc2).__name__}: {str(exc2)[:160]}"
                     await _progress("Dev", f"Iteration {iteration} retry also failed ({msg2}) — skipping")

--- a/src/theswarm/presentation/web/server.py
+++ b/src/theswarm/presentation/web/server.py
@@ -478,6 +478,16 @@ async def start_server(
     except Exception:
         log.exception("Orphan cycle reap failed (continuing startup)")
 
+    # Also reap periodically: an in-process hang past the whole-cycle hard
+    # timeout must not stay "running" until the next deploy. The age cutoff
+    # sits above CYCLE_HARD_TIMEOUT_SECONDS so live cycles are never reaped.
+    from theswarm.api import CYCLE_HARD_TIMEOUT_SECONDS
+    from theswarm.application.services.orphan_reaper import run_orphan_reap_loop
+
+    asyncio.create_task(run_orphan_reap_loop(
+        cycle_repo, max_age_seconds=CYCLE_HARD_TIMEOUT_SECONDS + 1800,
+    ))
+
     # Report storage
     from theswarm.infrastructure.recording.report_repo import SQLiteReportRepository
     from theswarm.infrastructure.recording.artifact_store import LocalArtifactStore

--- a/src/theswarm/tools/claude.py
+++ b/src/theswarm/tools/claude.py
@@ -36,6 +36,31 @@ _RETRYABLE_ERRORS: tuple[type[BaseException], ...] = (
     asyncio.TimeoutError,
 )
 
+# BadRequestError substrings that indicate an account-level problem (not a
+# malformed prompt): every subsequent call in the cycle will fail the same way.
+_FATAL_BAD_REQUEST_MARKERS = ("credit balance", "billing", "plans & billing")
+
+
+class ClaudeFatalError(Exception):
+    """Non-retryable Claude failure: billing, auth, or invalid credentials.
+
+    The same error would recur on every call, so the cycle should abort
+    immediately instead of retrying through remaining phases/iterations.
+    """
+
+
+def _classify_fatal(exc: BaseException) -> str | None:
+    """Return a human-readable reason if exc is account-fatal, else None."""
+    if isinstance(exc, anthropic.AuthenticationError):
+        return f"Anthropic authentication failed: {exc}"
+    if isinstance(exc, anthropic.PermissionDeniedError):
+        return f"Anthropic permission denied: {exc}"
+    if isinstance(exc, anthropic.BadRequestError):
+        msg = str(exc).lower()
+        if any(marker in msg for marker in _FATAL_BAD_REQUEST_MARKERS):
+            return f"Anthropic account/billing error: {exc}"
+    return None
+
 # Map short names to full model IDs
 _MODEL_MAP: dict[str, str] = {
     "sonnet": "claude-sonnet-4-20250514",
@@ -303,7 +328,13 @@ class ClaudeCLI:
                     timeout=effective_timeout,
                 )
                 break
-            except _RETRYABLE_ERRORS as exc:
+            except (anthropic.APIError, asyncio.TimeoutError) as exc:
+                fatal_reason = _classify_fatal(exc)
+                if fatal_reason is not None:
+                    log.error("Claude API fatal (non-retryable): %s", fatal_reason)
+                    raise ClaudeFatalError(fatal_reason) from exc
+                if not isinstance(exc, _RETRYABLE_ERRORS):
+                    raise
                 if attempt >= self.max_retries:
                     log.error(
                         "Claude API exhausted retries (%d): %s: %s",

--- a/src/theswarm/tools/git.py
+++ b/src/theswarm/tools/git.py
@@ -9,31 +9,58 @@ import shutil
 
 log = logging.getLogger(__name__)
 
-# Repo-local identity applied when the environment provides none (matches the
-# GIT_AUTHOR/COMMITTER values in docker-compose.yml). Prod cycles died with
-# rc=128 'Author identity unknown' when the deploy env lost those vars.
-_FALLBACK_IDENTITY_NAME = "TheSwarm Dev Agent"
-_FALLBACK_IDENTITY_EMAIL = "swarm-dev@jrec.fr"
+# Default committer identity for agent commits (matches the GIT_AUTHOR/
+# COMMITTER values in docker-compose.yml). In containers there is no global
+# git config, so `git commit` fails with rc=128 "Author identity unknown"
+# unless the identity is supplied explicitly.
+DEFAULT_GIT_USER_NAME = "TheSwarm Dev Agent"
+DEFAULT_GIT_USER_EMAIL = "swarm-dev@jrec.fr"
+
+# Hard cap on any single git command. Without it, a clone/push waiting on a
+# credential prompt hangs forever — outside the cycle's phase timeouts.
+GIT_COMMAND_TIMEOUT = 300
 
 
 async def _run_git(
     *args: str,
     cwd: str | None = None,
     check: bool = True,
+    timeout: float = GIT_COMMAND_TIMEOUT,
 ) -> str:
     """Run a git command and return stdout."""
+    env = {
+        **os.environ,
+        # Never prompt for credentials or SSH host confirmation — fail instead.
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_SSH_COMMAND": os.environ.get("GIT_SSH_COMMAND", "ssh -oBatchMode=yes"),
+    }
     proc = await asyncio.create_subprocess_exec(
         "git", *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        stdin=asyncio.subprocess.DEVNULL,
         cwd=cwd,
+        env=env,
     )
-    stdout, stderr = await proc.communicate()
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        raise RuntimeError(
+            f"git {' '.join(args)} timed out after {timeout:.0f}s"
+        ) from None
     if check and proc.returncode != 0:
         raise RuntimeError(
             f"git {' '.join(args)} failed (rc={proc.returncode}): {stderr.decode()[:500]}"
         )
     return stdout.decode().strip()
+
+
+def _identity_args() -> list[str]:
+    """Explicit committer identity flags, overridable via env."""
+    name = os.environ.get("SWARM_GIT_USER_NAME", DEFAULT_GIT_USER_NAME)
+    email = os.environ.get("SWARM_GIT_USER_EMAIL", DEFAULT_GIT_USER_EMAIL)
+    return ["-c", f"user.name={name}", "-c", f"user.email={email}"]
 
 
 async def clone_repo(repo_url: str, dest: str) -> str:
@@ -69,13 +96,17 @@ async def commit_all(workdir: str, message: str) -> bool:
         return False
 
     try:
-        await _run_git("commit", "-m", message, cwd=workdir)
+        await _run_git(*_identity_args(), "commit", "-m", message, cwd=workdir)
     except RuntimeError as exc:
         if "Author identity unknown" not in str(exc) and "user.email" not in str(exc):
             raise
+        # The -c flags should make this unreachable; if git still refuses,
+        # persist a repo-local identity and retry once.
         log.warning("No git identity in environment — setting repo-local fallback")
-        await _run_git("config", "user.name", _FALLBACK_IDENTITY_NAME, cwd=workdir)
-        await _run_git("config", "user.email", _FALLBACK_IDENTITY_EMAIL, cwd=workdir)
+        name = os.environ.get("SWARM_GIT_USER_NAME", DEFAULT_GIT_USER_NAME)
+        email = os.environ.get("SWARM_GIT_USER_EMAIL", DEFAULT_GIT_USER_EMAIL)
+        await _run_git("config", "user.name", name, cwd=workdir)
+        await _run_git("config", "user.email", email, cwd=workdir)
         await _run_git("commit", "-m", message, cwd=workdir)
     log.info("Committed: %s", message)
     return True

--- a/tests/application/test_orphan_reaper.py
+++ b/tests/application/test_orphan_reaper.py
@@ -1,0 +1,52 @@
+"""Periodic orphan reap loop — concludes stale cycles between deploys.
+
+Prod repro: reap_orphans only ran at server startup, so cycles hung on
+2026-04-23 stayed 'running' until the next deploy on 2026-04-25 11:50.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from theswarm.application.services.orphan_reaper import run_orphan_reap_loop
+
+
+class _FakeRepo:
+    def __init__(self, fail_first: bool = False) -> None:
+        self.calls: list[int] = []
+        self._fail_first = fail_first
+
+    async def reap_orphans(self, *, max_age_seconds: int) -> int:
+        self.calls.append(max_age_seconds)
+        if self._fail_first and len(self.calls) == 1:
+            raise RuntimeError("db locked")
+        return 1
+
+
+async def _run_loop_briefly(repo: _FakeRepo, min_calls: int) -> None:
+    task = asyncio.create_task(
+        run_orphan_reap_loop(repo, max_age_seconds=12600, interval_seconds=0.01),
+    )
+    try:
+        async with asyncio.timeout(2.0):
+            while len(repo.calls) < min_calls:
+                await asyncio.sleep(0.01)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_loop_reaps_repeatedly_with_max_age():
+    repo = _FakeRepo()
+    await _run_loop_briefly(repo, min_calls=3)
+    assert len(repo.calls) >= 3
+    assert all(age == 12600 for age in repo.calls)
+
+
+async def test_loop_survives_repo_errors():
+    repo = _FakeRepo(fail_first=True)
+    await _run_loop_briefly(repo, min_calls=2)
+    assert len(repo.calls) >= 2  # kept looping after the first call raised

--- a/tests/test_api_cycle_hard_timeout.py
+++ b/tests/test_api_cycle_hard_timeout.py
@@ -1,0 +1,61 @@
+"""Whole-cycle hard timeout in run_api_cycle.
+
+Prod repro (cycles 338a005e3cea, d70c60edeca3, a3204c6b1b89, efcacbcda4be):
+cycles hung 14–42h with a phase stuck 'running'. Per-phase timeouts don't
+cover everything (workspace clone, retrospective, …), so run_api_cycle now
+caps the whole cycle and concludes the record with a clear error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from theswarm import api as api_mod
+from theswarm.api import CycleRequest, CycleStatus, get_cycle_tracker, run_api_cycle
+
+
+async def test_hung_cycle_is_concluded_by_hard_timeout(monkeypatch):
+    monkeypatch.setattr(api_mod, "CYCLE_HARD_TIMEOUT_SECONDS", 0.1)
+
+    async def hang(*_a, **_kw):
+        await asyncio.sleep(30)
+
+    tracker = get_cycle_tracker()
+    record = tracker.create(CycleRequest(repo="owner/some-repo"))
+
+    with patch("theswarm.cycle.run_daily_cycle", side_effect=hang):
+        await run_api_cycle(
+            cycle_id=record.id,
+            repo="owner/some-repo",
+            description="",
+            callback_url="",
+            allowed_repos=[],
+        )
+
+    final = tracker.get(record.id)
+    assert final is not None
+    assert final.status == CycleStatus.FAILED
+    assert "hard timeout" in (final.error or "")
+    assert final.completed_at  # record is concluded, not left running
+
+
+async def test_fast_cycle_unaffected_by_hard_timeout():
+    async def quick(*_a, **_kw):
+        return {"date": "2026-07-30", "cost_usd": 0.0, "prs": [], "reviews": []}
+
+    tracker = get_cycle_tracker()
+    record = tracker.create(CycleRequest(repo="owner/some-repo"))
+
+    with patch("theswarm.cycle.run_daily_cycle", side_effect=quick):
+        await run_api_cycle(
+            cycle_id=record.id,
+            repo="owner/some-repo",
+            description="",
+            callback_url="",
+            allowed_repos=[],
+        )
+
+    final = tracker.get(record.id)
+    assert final is not None
+    assert final.status == CycleStatus.COMPLETED

--- a/tests/test_claude_fatal.py
+++ b/tests/test_claude_fatal.py
@@ -1,0 +1,99 @@
+"""ClaudeFatalError — billing/auth API errors abort instead of retrying.
+
+Prod repro (cycles 3859db29d158, a6e06fb5b4b7, ce2d429c6c81): the API
+returned 400 invalid_request_error "Your credit balance is too low…" and the
+raw BadRequestError crashed phases one after another. These errors are
+account-level: they must surface as a typed, non-retryable failure.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import anthropic
+import httpx
+import pytest
+
+from theswarm.tools.claude import ClaudeCLI, ClaudeFatalError, _classify_fatal
+
+CREDIT_MSG = (
+    "Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', "
+    "'message': 'Your credit balance is too low to access the Anthropic API. "
+    "Please go to Plans & Billing to upgrade or purchase credits.'}}"
+)
+
+
+def _bad_request(message: str) -> anthropic.BadRequestError:
+    req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    resp = httpx.Response(400, request=req)
+    return anthropic.BadRequestError(message=message, response=resp, body=None)
+
+
+def _auth_error() -> anthropic.AuthenticationError:
+    req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    resp = httpx.Response(401, request=req)
+    return anthropic.AuthenticationError(message="invalid x-api-key", response=resp, body=None)
+
+
+# ── _classify_fatal ────────────────────────────────────────────────────
+
+
+def test_credit_balance_bad_request_is_fatal():
+    reason = _classify_fatal(_bad_request(CREDIT_MSG))
+    assert reason is not None
+    assert "billing" in reason.lower() or "account" in reason.lower()
+
+
+def test_other_bad_request_is_not_fatal():
+    assert _classify_fatal(_bad_request("max_tokens exceeds model limit")) is None
+
+
+def test_authentication_error_is_fatal():
+    assert _classify_fatal(_auth_error()) is not None
+
+
+def test_rate_limit_is_not_fatal():
+    req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    resp = httpx.Response(429, request=req)
+    err = anthropic.RateLimitError(message="rate limited", response=resp, body=None)
+    assert _classify_fatal(err) is None
+
+
+# ── API path raises ClaudeFatalError without retrying ──────────────────
+
+
+async def test_api_billing_error_raises_fatal_without_retry(monkeypatch):
+    monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "api")
+    cli = ClaudeCLI(model="haiku", max_retries=3, retry_base_ms=10)
+    cli._sleep = AsyncMock()
+
+    calls = 0
+
+    async def fake_create(**_kw):
+        nonlocal calls
+        calls += 1
+        raise _bad_request(CREDIT_MSG)
+
+    with patch("anthropic.AsyncAnthropic") as mock_client:
+        mock_client.return_value.messages.create = AsyncMock(side_effect=fake_create)
+        with pytest.raises(ClaudeFatalError, match="billing"):
+            await cli.run("hi")
+
+    assert calls == 1
+    cli._sleep.assert_not_called()
+
+
+async def test_api_non_billing_bad_request_propagates_raw(monkeypatch):
+    monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "api")
+    cli = ClaudeCLI(model="haiku", max_retries=3, retry_base_ms=10)
+    cli._sleep = AsyncMock()
+
+    async def fake_create(**_kw):
+        raise _bad_request("max_tokens exceeds model limit")
+
+    with patch("anthropic.AsyncAnthropic") as mock_client:
+        mock_client.return_value.messages.create = AsyncMock(side_effect=fake_create)
+        with pytest.raises(anthropic.BadRequestError):
+            await cli.run("hi")
+
+    cli._sleep.assert_not_called()

--- a/tests/test_cycle_fatal_abort.py
+++ b/tests/test_cycle_fatal_abort.py
@@ -1,0 +1,56 @@
+"""Dev loop aborts the cycle on ClaudeFatalError instead of retrying.
+
+Prod repro (cycle a6e06fb5b4b7): every Claude call failed with the same
+billing 400, yet each dev iteration retried once — burning minutes before
+the cycle finally crashed with an opaque error deep in the QA phase.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from theswarm import cycle as cycle_mod
+from theswarm.cycle import run_daily_cycle
+from theswarm.config import CycleConfig
+from theswarm.tools.claude import ClaudeFatalError
+
+
+def _fatal_graph_factory(counter: dict):
+    class _Fatal:
+        async def ainvoke(self, _state):
+            counter["calls"] += 1
+            raise ClaudeFatalError("Anthropic account/billing error: credit balance too low")
+    return lambda: _Fatal()
+
+
+async def test_dev_fatal_error_aborts_cycle_without_retry():
+    config = CycleConfig(github_repo="")  # stub mode — no workspace clone
+    counter = {"calls": 0}
+
+    with patch.object(cycle_mod, "build_dev_graph", _fatal_graph_factory(counter)):
+        with pytest.raises(ClaudeFatalError, match="billing"):
+            await run_daily_cycle(config)
+
+    # One invocation, no retry, no further iterations
+    assert counter["calls"] == 1
+
+
+async def test_dev_fatal_error_on_retry_also_aborts():
+    """First failure is generic (retry allowed), the retry hits the fatal error."""
+    config = CycleConfig(github_repo="")
+    counter = {"calls": 0}
+
+    class _GenericThenFatal:
+        async def ainvoke(self, _state):
+            counter["calls"] += 1
+            if counter["calls"] == 1:
+                raise RuntimeError("transient network blip")
+            raise ClaudeFatalError("Anthropic account/billing error: credit balance too low")
+
+    with patch.object(cycle_mod, "build_dev_graph", lambda: _GenericThenFatal()):
+        with pytest.raises(ClaudeFatalError):
+            await run_daily_cycle(config)
+
+    assert counter["calls"] == 2

--- a/tests/test_tools_git.py
+++ b/tests/test_tools_git.py
@@ -133,7 +133,7 @@ async def test_commit_all_sets_identity_fallback_on_rc128(mocker):
         proc.returncode = 0
         if args[1] == "status":
             proc.communicate = AsyncMock(return_value=(b"M file.py", b""))
-        elif args[1] == "commit":
+        elif "commit" in args:
             commit_attempts += 1
             if commit_attempts == 1:
                 proc.returncode = 128
@@ -166,7 +166,7 @@ async def test_commit_all_other_error_still_raises(mocker):
         proc.returncode = 0
         if args[1] == "status":
             proc.communicate = AsyncMock(return_value=(b"M file.py", b""))
-        elif args[1] == "commit":
+        elif "commit" in args:
             proc.returncode = 1
             proc.communicate = AsyncMock(return_value=(b"", b"pre-commit hook failed"))
         else:
@@ -196,6 +196,142 @@ async def test_commit_all_no_changes(mocker):
     # Only 2 calls: add -A, status --porcelain (no commit)
     import asyncio
     assert asyncio.create_subprocess_exec.call_count == 2
+
+
+async def test_commit_all_passes_explicit_identity(mocker):
+    """Commit must carry -c user.name/user.email — containers have no git config."""
+    commit_calls = []
+
+    async def fake_subprocess(*args, **kwargs):
+        proc = AsyncMock()
+        proc.returncode = 0
+        if args[1] == "status":
+            proc.communicate = AsyncMock(return_value=(b"M file.py", b""))
+        else:
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+        if "commit" in args:
+            commit_calls.append(args)
+        return proc
+
+    mocker.patch("asyncio.create_subprocess_exec", side_effect=fake_subprocess)
+    await commit_all("/tmp/repo", "feat: x")
+
+    assert len(commit_calls) == 1
+    args = commit_calls[0]
+    assert "user.name=TheSwarm Dev Agent" in args
+    assert "user.email=swarm-dev@jrec.fr" in args
+    # -c flags must come before the subcommand
+    assert args.index("user.name=TheSwarm Dev Agent") < args.index("commit")
+
+
+async def test_commit_all_identity_env_override(mocker, monkeypatch):
+    monkeypatch.setenv("SWARM_GIT_USER_NAME", "custom-bot")
+    monkeypatch.setenv("SWARM_GIT_USER_EMAIL", "bot@example.com")
+    commit_calls = []
+
+    async def fake_subprocess(*args, **kwargs):
+        proc = AsyncMock()
+        proc.returncode = 0
+        if args[1] == "status":
+            proc.communicate = AsyncMock(return_value=(b"M file.py", b""))
+        else:
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+        if "commit" in args:
+            commit_calls.append(args)
+        return proc
+
+    mocker.patch("asyncio.create_subprocess_exec", side_effect=fake_subprocess)
+    await commit_all("/tmp/repo", "feat: x")
+
+    assert "user.name=custom-bot" in commit_calls[0]
+    assert "user.email=bot@example.com" in commit_calls[0]
+
+
+async def test_commit_all_multiline_message_is_single_argv(mocker):
+    """The multi-line PR-closing message travels as ONE argv element."""
+    message = (
+        "feat: Verify LICENSE file follows standard conventions\n\n"
+        "Closes #173\n\n"
+        "Co-Authored-By: swarm-dev-agent <agent@swarm-bots.local>"
+    )
+    commit_calls = []
+
+    async def fake_subprocess(*args, **kwargs):
+        proc = AsyncMock()
+        proc.returncode = 0
+        if args[1] == "status":
+            proc.communicate = AsyncMock(return_value=(b"M file.py", b""))
+        else:
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+        if "commit" in args:
+            commit_calls.append(args)
+        return proc
+
+    mocker.patch("asyncio.create_subprocess_exec", side_effect=fake_subprocess)
+    await commit_all("/tmp/repo", message)
+
+    args = commit_calls[0]
+    assert args[args.index("-m") + 1] == message
+
+
+async def test_run_git_timeout_kills_and_raises(mocker):
+    """A git command hanging (e.g. credential prompt) is killed, not awaited forever."""
+    import asyncio as _asyncio
+
+    proc = AsyncMock()
+    proc.returncode = None
+
+    async def hang():
+        await _asyncio.sleep(30)
+
+    proc.communicate = hang
+    proc.kill = lambda: None
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        await _run_git("clone", "https://example.com/r.git", timeout=0.05)
+
+
+async def test_run_git_disables_credential_prompts(mock_subprocess):
+    import asyncio
+
+    await _run_git("fetch")
+    kwargs = asyncio.create_subprocess_exec.call_args.kwargs
+    assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert "BatchMode=yes" in kwargs["env"]["GIT_SSH_COMMAND"]
+
+
+async def test_commit_all_real_repo_without_identity(tmp_path, monkeypatch):
+    """Prod repro (cycle adf70608e595): container git has no identity configured.
+
+    ``user.useConfigOnly=true`` makes git refuse to guess from the OS user,
+    which is exactly the 'Author identity unknown' rc=128 seen in prod.
+    The explicit -c identity flags in commit_all must make the commit pass.
+    """
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+    monkeypatch.delenv("SWARM_GIT_USER_NAME", raising=False)
+    monkeypatch.delenv("SWARM_GIT_USER_EMAIL", raising=False)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    await _run_git("init", "-q", cwd=str(repo))
+    await _run_git("config", "user.useConfigOnly", "true", cwd=str(repo))
+    (repo / "f.txt").write_text("x\n")
+
+    # The exact multi-line message shape that failed in prod
+    message = (
+        "feat: Verify LICENSE file follows standard conventions\n\n"
+        "Closes #173\n\n"
+        "Co-Authored-By: swarm-dev-agent <agent@swarm-bots.local>"
+    )
+    committed = await commit_all(str(repo), message)
+    assert committed is True
+
+    body = await _run_git("log", "-1", "--pretty=%B", cwd=str(repo))
+    author = await _run_git("log", "-1", "--pretty=%an <%ae>", cwd=str(repo))
+    assert "Closes #173" in body
+    assert author == "TheSwarm Dev Agent <swarm-dev@jrec.fr>"
 
 
 # ── push_branch ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the three failure modes observed on the 10 real April cycles against `jrechet/concert-tour-app` (9 failed / 1 completed / 0 PR merged):

1. **Dev — `git commit` rc=128 « Author identity unknown »** (cycle adf70608e595). Not a message-escaping issue: the container has no git identity. `commit_all` now passes explicit `-c user.name/user.email` (overridable via `SWARM_GIT_USER_NAME/EMAIL`). Every git command also gets a 300s hard timeout, `GIT_TERMINAL_PROMPT=0` and ssh `BatchMode=yes` so credential prompts fail fast instead of hanging forever.

2. **QA/Dev — anthropic 400 « credit balance is too low »** (cycles 3859db29d158, a6e06fb5b4b7, ce2d429c6c81). Billing/auth errors are now classified as `ClaudeFatalError` (non-retryable); the dev loop aborts the cycle immediately with a clear message instead of retrying each iteration and crashing later in QA.

3. **Cycles stuck 'running' 14–42h** (338a005e3cea, d70c60edeca3, a3204c6b1b89, efcacbcda4be). `reap_orphans` only ran at server startup, so stale rows survived until the next deploy (all were concluded at the same timestamp, 2026-04-25T11:50:08). Added: a periodic reap loop (15 min, age cutoff above the cycle hard timeout so live cycles are never reaped) and a whole-cycle hard timeout (`SWARM_CYCLE_TIMEOUT`, default 3h) in `run_api_cycle` as backstop for hangs outside per-phase scopes (workspace clone runs before any phase timeout).

## Test plan

- [x] Real-repo repro of the rc=128 identity failure (`user.useConfigOnly=true`) — commit now passes with the exact prod multi-line message
- [x] Fatal-classification unit tests (billing 400 → fatal, other 400 → raw, 429 → retryable)
- [x] Cycle aborts on `ClaudeFatalError` without retry (both first-attempt and retry paths)
- [x] `run_api_cycle` hard timeout concludes a hung cycle as failed with a clear error
- [x] Periodic reaper loop reaps repeatedly and survives repo errors
- [x] Full suite: 2167 passed
- [ ] Post-deploy: relaunch a real cycle on concert-tour-app and verify end-to-end