### PR TITLE
refactor(sidebar): opt the nav out of Pico's <nav> styling entirely

### DIFF
--- a/src/theswarm/presentation/web/static/css/dashboard.css
+++ b/src/theswarm/presentation/web/static/css/dashboard.css
@@ -191,15 +191,10 @@ html[data-sidebar="collapsed"] .sidebar-resize-handle { display: none; }
 .sidebar-nav details[open] > summary::after { transform: rotate(90deg); }
 .sidebar-nav summary:hover { color: var(--text-primary); }
 
-/* Override Pico's `nav ul { display:flex; align-items:center }`
- * and `nav li { display:inline-block }`. The :first-of-type/:last-of-type
- * co-selectors are needed to outrank Pico's
- * `nav ul:first-of-type { margin-left: calc(spacing * -1) }` (0-1-2),
- * which otherwise beats a bare `.sidebar-nav ul` (0-1-1) and drags the
- * list off the left edge — clipping the first characters of every label. */
-.sidebar-nav ul,
-.sidebar-nav ul:first-of-type,
-.sidebar-nav ul:last-of-type {
+/* The nav container is a <div role="navigation">, NOT a <nav> element —
+ * Pico styles every <nav> (flex row, centered items, negative ul margins)
+ * and kept clipping labels. Plain lists, plain rules. */
+.sidebar-nav ul {
   list-style: none;
   padding: 0 0 0.25rem;
   margin: 0;
@@ -217,8 +212,6 @@ html[data-sidebar="collapsed"] .sidebar-resize-handle { display: none; }
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  /* Pico's `nav li :where(a)` applies negative margins to pull links flush
-   * with the nav edge; reset them or labels get clipped. */
   margin: 0;
   padding: 0.4rem 0.75rem;
   border-radius: var(--radius-sm);

--- a/src/theswarm/presentation/web/templates/base.html
+++ b/src/theswarm/presentation/web/templates/base.html
@@ -19,13 +19,17 @@
     <span class="visually-hidden">Toggle sidebar</span>
   </button>
 
-  <aside id="sidebar" class="sidebar" aria-label="Main navigation">
+  <aside id="sidebar" class="sidebar">
     <a href="{{ base }}/" class="sidebar-logo">
       <span class="sidebar-logo-mark">⬡</span>
       <span class="sidebar-logo-text">TheSwarm</span>
     </a>
 
-    <nav class="sidebar-nav">
+    <!-- div + role=navigation instead of <nav>: Pico styles every <nav>
+         (flex row, centered items, negative ul margins) and its element
+         selectors kept outranking our overrides. Opting out of the tag
+         opts out of the whole fight. -->
+    <div class="sidebar-nav" role="navigation" aria-label="Main navigation">
       <details open>
         <summary>Workspace</summary>
         <ul>
@@ -78,7 +82,7 @@
           <li><a href="{{ base }}/health/ready/page" data-icon="♥"><span>Health</span></a></li>
         </ul>
       </details>
-    </nav>
+    </div>
 
     <footer class="sidebar-footer">
       <div class="sidebar-status" id="sse-status" title="Server-sent events stream — used for live cycle updates">


### PR DESCRIPTION
Follow-up to #9. Pico styles every `<nav>` element and its element selectors kept outranking our class overrides — each fix was another specificity patch. This replaces the `<nav>` tag with `<div role="navigation">` (same accessibility semantics) so none of Pico's nav rules can ever match the sidebar again, and drops the now-dead compensation selectors. KISS.

- [x] 450 presentation + GA-smoke tests pass
- [x] Verified locally at 375 and 1280: labels complete, icons rendered, toggle/logo hit targets separate

🤖 Generated with [Claude Code](https://claude.com/claude-code)