### PR TITLE
fix(claude): update retired model IDs to current aliases

### DIFF
--- a/src/theswarm/tools/claude.py
+++ b/src/theswarm/tools/claude.py
@@ -61,11 +61,13 @@ def _classify_fatal(exc: BaseException) -> str | None:
             return f"Anthropic account/billing error: {exc}"
     return None
 
-# Map short names to full model IDs
+# Map short names to model IDs (aliases, no date suffix — kept current).
+# Prod cycle 129d471406b1: the CLI 404'd on the retired claude-sonnet-4-*
+# date-pinned ID, silently falling back to the API path.
 _MODEL_MAP: dict[str, str] = {
-    "sonnet": "claude-sonnet-4-20250514",
-    "opus": "claude-opus-4-20250514",
-    "haiku": "claude-haiku-4-5-20251001",
+    "sonnet": "claude-sonnet-5",
+    "opus": "claude-opus-5",
+    "haiku": "claude-haiku-4-5",
 }
 
 
@@ -82,14 +84,14 @@ class ClaudeResult:
 
 # Approximate pricing per 1M tokens (USD) — used for the API path.
 _INPUT_COST: dict[str, float] = {
-    "claude-sonnet-4-20250514": 3.0,
-    "claude-opus-4-20250514": 15.0,
-    "claude-haiku-4-5-20251001": 0.80,
+    "claude-sonnet-5": 3.0,
+    "claude-opus-5": 5.0,
+    "claude-haiku-4-5": 1.0,
 }
 _OUTPUT_COST: dict[str, float] = {
-    "claude-sonnet-4-20250514": 15.0,
-    "claude-opus-4-20250514": 75.0,
-    "claude-haiku-4-5-20251001": 4.0,
+    "claude-sonnet-5": 15.0,
+    "claude-opus-5": 25.0,
+    "claude-haiku-4-5": 5.0,
 }
 
 

--- a/tests/test_tools_claude.py
+++ b/tests/test_tools_claude.py
@@ -11,18 +11,18 @@ class TestEstimateCost:
     def test_sonnet_cost(self):
         # 1M input + 1M output: input $3.00 + output $15.00 = $18.00
         # With 1000 tokens: 3.0 * 1000 / 1_000_000 + 15.0 * 1000 / 1_000_000
-        cost = _estimate_cost("claude-sonnet-4-20250514", 1_000_000, 1_000_000)
+        cost = _estimate_cost("claude-sonnet-5", 1_000_000, 1_000_000)
         assert cost == pytest.approx(18.0, abs=0.01)
 
     def test_opus_cost(self):
-        # 1M input + 1M output: input $15.00 + output $75.00 = $90.00
-        cost = _estimate_cost("claude-opus-4-20250514", 1_000_000, 1_000_000)
-        assert cost == pytest.approx(90.0, abs=0.01)
+        # 1M input + 1M output: input $5.00 + output $25.00 = $30.00
+        cost = _estimate_cost("claude-opus-5", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(30.0, abs=0.01)
 
     def test_haiku_cost(self):
-        # 1M input + 1M output: input $0.80 + output $4.00 = $4.80
-        cost = _estimate_cost("claude-haiku-4-5-20251001", 1_000_000, 1_000_000)
-        assert cost == pytest.approx(4.80, abs=0.01)
+        # 1M input + 1M output: input $1.00 + output $5.00 = $6.00
+        cost = _estimate_cost("claude-haiku-4-5", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(6.00, abs=0.01)
 
     def test_unknown_model_uses_default_rates(self):
         # Default rates: input=3.0, output=15.0 (same as sonnet)
@@ -30,32 +30,32 @@ class TestEstimateCost:
         assert cost == pytest.approx(18.0, abs=0.01)
 
     def test_zero_tokens(self):
-        cost = _estimate_cost("claude-sonnet-4-20250514", 0, 0)
+        cost = _estimate_cost("claude-sonnet-5", 0, 0)
         assert cost == 0.0
 
     def test_large_token_count(self):
         # 1M input tokens for sonnet: 3.0 * 1M / 1M = $3.00
         # 1M output tokens for sonnet: 15.0 * 1M / 1M = $15.00
-        cost = _estimate_cost("claude-sonnet-4-20250514", 1_000_000, 1_000_000)
+        cost = _estimate_cost("claude-sonnet-5", 1_000_000, 1_000_000)
         assert cost == pytest.approx(18.0, abs=0.01)
 
 
 class TestResolveModel:
     def test_sonnet_short_name(self):
         cli = ClaudeCLI(model="sonnet")
-        assert cli._resolve_model() == "claude-sonnet-4-20250514"
+        assert cli._resolve_model() == "claude-sonnet-5"
 
     def test_opus_short_name(self):
         cli = ClaudeCLI(model="opus")
-        assert cli._resolve_model() == "claude-opus-4-20250514"
+        assert cli._resolve_model() == "claude-opus-5"
 
     def test_haiku_short_name(self):
         cli = ClaudeCLI(model="haiku")
-        assert cli._resolve_model() == "claude-haiku-4-5-20251001"
+        assert cli._resolve_model() == "claude-haiku-4-5"
 
     def test_full_model_id_passthrough(self):
-        cli = ClaudeCLI(model="claude-sonnet-4-20250514")
-        assert cli._resolve_model() == "claude-sonnet-4-20250514"
+        cli = ClaudeCLI(model="claude-sonnet-5")
+        assert cli._resolve_model() == "claude-sonnet-5"
 
     def test_unknown_model_passthrough(self):
         cli = ClaudeCLI(model="my-custom-model")
@@ -79,11 +79,11 @@ class TestClaudeResult:
             output_tokens=200,
             total_tokens=700,
             cost_usd=0.0045,
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-5",
         )
         assert result.text == "response"
         assert result.input_tokens == 500
         assert result.output_tokens == 200
         assert result.total_tokens == 700
         assert result.cost_usd == pytest.approx(0.0045)
-        assert result.model == "claude-sonnet-4-20250514"
+        assert result.model == "claude-sonnet-5"

--- a/tests/test_tools_claude_run.py
+++ b/tests/test_tools_claude_run.py
@@ -31,7 +31,7 @@ async def test_run_basic():
     assert result.output_tokens == 50
     assert result.total_tokens == 150
     assert result.cost_usd > 0
-    assert result.model == "claude-sonnet-4-20250514"
+    assert result.model == "claude-sonnet-5"
 
 
 async def test_run_with_workdir():


### PR DESCRIPTION
Root cause of the failed validation cycle 129d471406b1: the Claude CLI 404'd on the retired date-pinned `claude-sonnet-4-20250514`, silently fell back to the API path where `ANTHROPIC_API_KEY` holds an sk-ant-oat OAuth token rejected on the x-api-key header → 401, now surfaced as a clean `ClaudeFatalError` (the new fail-fast worked as designed — cycle concluded in 2 min with a clear error instead of hanging).

- `_MODEL_MAP`: `sonnet`→`claude-sonnet-5`, `opus`→`claude-opus-5`, `haiku`→`claude-haiku-4-5` (verified working via the CLI inside the prod container)
- refreshed API-path pricing table
- tests updated (2171 passing)