### PR TITLE
fix(cycle): stop the API-fallback trap and the endless Ralph Loop

### DIFF
--- a/src/theswarm/config.py
+++ b/src/theswarm/config.py
@@ -63,6 +63,7 @@ class AgentState(TypedDict, total=False):
     issue_stats: dict
     demo_report: dict | None
     demo_artifacts: list  # list of (Artifact, bytes) tuples from screenshot capture
+    video_artifacts: list  # (Artifact, bytes) from record_demo_video → generate_demo_report
     story_preview_urls: dict  # F2 — {pr_number: {"before": url_or_none, "after": url}}
     story_artifacts: dict  # F2 — {pr_number: {"before": [...], "after": [...]}}
     story_videos: dict  # F3 — {pr_number: (Artifact, bytes)}

--- a/src/theswarm/config.py
+++ b/src/theswarm/config.py
@@ -44,6 +44,11 @@ class AgentState(TypedDict, total=False):
     tests_passed: bool
     test_output: str
     diff_stat: str
+    # Ralph Loop retry accounting. LangGraph drops keys absent from this
+    # schema, so omitting these pinned retry_count at 0 and the dev loop
+    # retried until the phase timeout (prod cycle 65ab4b0fdf3e).
+    retry_count: int
+    max_dev_retries: int
     blockers: list[dict]
     pr: dict | None
     # TechLead-specific

--- a/src/theswarm/cycle.py
+++ b/src/theswarm/cycle.py
@@ -140,6 +140,9 @@ def _build_base_state(config: CycleConfig) -> dict:
         "github": None,
         "claude": None,
         "workspace": None,
+        # Honour the project's configured retry budget instead of the
+        # dev-graph default.
+        "max_dev_retries": config.max_dev_retries,
     }
 
     if config.is_real_mode:

--- a/src/theswarm/tools/claude.py
+++ b/src/theswarm/tools/claude.py
@@ -116,6 +116,19 @@ def _resolve_backend_mode() -> str:
     return "auto"
 
 
+def _api_backend_viable() -> bool:
+    """True when ANTHROPIC_API_KEY can actually authenticate the Messages API.
+
+    ``sk-ant-oat`` tokens come from ``claude setup-token`` and are only
+    accepted through the CLI's ``Authorization: Bearer`` flow — the API's
+    ``x-api-key`` header rejects them with 401. Falling back to the API while
+    holding one turns any transient CLI failure into a fatal auth error
+    (prod cycle 65ab4b0fdf3e), so check before falling back.
+    """
+    key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    return bool(key) and not key.startswith("sk-ant-oat")
+
+
 @dataclass
 class ClaudeCLI:
     """Runs a prompt through Claude Code CLI first, Anthropic API as fallback.
@@ -175,14 +188,39 @@ class ClaudeCLI:
         """
         backend = _resolve_backend_mode()
 
-        if backend != "api":
+        if backend == "api":
+            return await self._run_api(prompt, workdir=workdir, timeout=timeout)
+
+        try:
+            return await self._run_cli(prompt, workdir=workdir, timeout=timeout)
+        except _CLIUnavailable as exc:
+            first_error = exc
+
+        if backend == "cli":
+            raise RuntimeError(
+                f"Claude CLI unavailable (forced): {first_error}"
+            ) from first_error
+
+        # Auto mode. Falling back to the API only helps when the API can
+        # authenticate; with an OAuth session token it always 401s, so a
+        # transient CLI hiccup would become a fatal cycle error. Retry the
+        # CLI once instead and surface its real failure.
+        if not _api_backend_viable():
+            log.warning(
+                "Claude CLI failed (%s) and the API fallback cannot authenticate "
+                "(no usable ANTHROPIC_API_KEY) — retrying the CLI once",
+                first_error,
+            )
             try:
                 return await self._run_cli(prompt, workdir=workdir, timeout=timeout)
-            except _CLIUnavailable as exc:
-                if backend == "cli":
-                    raise RuntimeError(f"Claude CLI unavailable (forced): {exc}") from exc
-                log.warning("Claude CLI unavailable (%s) — falling back to API", exc)
+            except _CLIUnavailable as retry_error:
+                raise RuntimeError(
+                    "Claude CLI failed twice and no usable API credential is "
+                    f"available (ANTHROPIC_API_KEY is unset or an OAuth token): "
+                    f"{retry_error}"
+                ) from retry_error
 
+        log.warning("Claude CLI unavailable (%s) — falling back to API", first_error)
         return await self._run_api(prompt, workdir=workdir, timeout=timeout)
 
     async def _run_cli(

--- a/src/theswarm/tools/claude.py
+++ b/src/theswarm/tools/claude.py
@@ -61,11 +61,13 @@ def _classify_fatal(exc: BaseException) -> str | None:
             return f"Anthropic account/billing error: {exc}"
     return None
 
-# Map short names to full model IDs
+# Map short names to model IDs (aliases, no date suffix — kept current).
+# Prod cycle 129d471406b1: the CLI 404'd on the retired claude-sonnet-4-*
+# date-pinned ID, silently falling back to the API path.
 _MODEL_MAP: dict[str, str] = {
-    "sonnet": "claude-sonnet-4-20250514",
-    "opus": "claude-opus-4-20250514",
-    "haiku": "claude-haiku-4-5-20251001",
+    "sonnet": "claude-sonnet-5",
+    "opus": "claude-opus-5",
+    "haiku": "claude-haiku-4-5",
 }
 
 
@@ -82,14 +84,14 @@ class ClaudeResult:
 
 # Approximate pricing per 1M tokens (USD) — used for the API path.
 _INPUT_COST: dict[str, float] = {
-    "claude-sonnet-4-20250514": 3.0,
-    "claude-opus-4-20250514": 15.0,
-    "claude-haiku-4-5-20251001": 0.80,
+    "claude-sonnet-5": 3.0,
+    "claude-opus-5": 5.0,
+    "claude-haiku-4-5": 1.0,
 }
 _OUTPUT_COST: dict[str, float] = {
-    "claude-sonnet-4-20250514": 15.0,
-    "claude-opus-4-20250514": 75.0,
-    "claude-haiku-4-5-20251001": 4.0,
+    "claude-sonnet-5": 15.0,
+    "claude-opus-5": 25.0,
+    "claude-haiku-4-5": 5.0,
 }
 
 

--- a/tests/test_agent_state_schema.py
+++ b/tests/test_agent_state_schema.py
@@ -1,0 +1,55 @@
+"""Every key a graph node hands to a later node must be in AgentState.
+
+LangGraph builds its channels from the state schema and silently discards
+returned keys the schema does not declare. Two prod bugs came from this:
+``retry_count`` (dev loop retried forever, cycle 65ab4b0fdf3e) and
+``video_artifacts`` (demo videos never reached the report). This test
+guards the whole class rather than the two known instances.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+from theswarm.config import AgentState
+
+AGENTS_DIR = pathlib.Path(__file__).resolve().parents[1] / "src" / "theswarm" / "agents"
+
+# Keys returned by plain helper functions rather than graph nodes. These are
+# collected into a declared key (e.g. reviews) instead of flowing through the
+# graph state, so the schema does not need them.
+HELPER_ONLY_KEYS = {"decision", "summary", "issues", "pr_number"}
+
+
+def _returned_dict_keys(path: pathlib.Path) -> set[str]:
+    keys: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text())):
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Dict):
+            keys.update(
+                k.value
+                for k in node.value.keys
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)
+            )
+    return keys
+
+
+def test_no_agent_returns_an_undeclared_state_key():
+    declared = set(AgentState.__annotations__)
+    undeclared: dict[str, set[str]] = {}
+
+    for path in sorted(AGENTS_DIR.glob("*.py")):
+        for key in _returned_dict_keys(path) - declared - HELPER_ONLY_KEYS:
+            undeclared.setdefault(key, set()).add(path.name)
+
+    assert not undeclared, (
+        "These keys are returned by agent code but missing from AgentState, so "
+        f"LangGraph will drop them on state merge: {undeclared}"
+    )
+
+
+def test_known_regressions_stay_declared():
+    """Explicit guards for the two keys that were dropped in production."""
+    declared = set(AgentState.__annotations__)
+    assert "retry_count" in declared
+    assert "video_artifacts" in declared

--- a/tests/test_claude_cli_backend.py
+++ b/tests/test_claude_cli_backend.py
@@ -81,6 +81,9 @@ class TestCLIBackendSuccess:
 class TestCLIFallbackToAPI:
     async def test_binary_missing_falls_back(self, monkeypatch):
         monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "auto")
+        # A real API key — the fallback is skipped when the key is an
+        # OAuth token the Messages API cannot accept.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-test")
         cli = ClaudeCLI(model="haiku", max_retries=0)
 
         with (
@@ -97,6 +100,9 @@ class TestCLIFallbackToAPI:
 
     async def test_cli_nonzero_exit_falls_back(self, monkeypatch):
         monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "auto")
+        # A real API key — the fallback is skipped when the key is an
+        # OAuth token the Messages API cannot accept.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-test")
         cli = ClaudeCLI(model="haiku", max_retries=0)
 
         with (
@@ -119,6 +125,9 @@ class TestCLIFallbackToAPI:
 
     async def test_cli_bad_json_falls_back(self, monkeypatch):
         monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "auto")
+        # A real API key — the fallback is skipped when the key is an
+        # OAuth token the Messages API cannot accept.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-test")
         cli = ClaudeCLI(model="haiku", max_retries=0)
 
         with (
@@ -139,6 +148,9 @@ class TestCLIFallbackToAPI:
 
     async def test_cli_reports_is_error_falls_back(self, monkeypatch):
         monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "auto")
+        # A real API key — the fallback is skipped when the key is an
+        # OAuth token the Messages API cannot accept.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-test")
         cli = ClaudeCLI(model="haiku", max_retries=0)
 
         env = _cli_envelope(is_error=True, text="quota exhausted")

--- a/tests/test_claude_no_api_fallback.py
+++ b/tests/test_claude_no_api_fallback.py
@@ -1,0 +1,120 @@
+"""The API fallback must not fire when the API cannot authenticate.
+
+Prod repro (cycle 65ab4b0fdf3e): the CLI hung transiently under load, the
+auto-mode fallback hit the Messages API with the deployment's
+``sk-ant-oat`` OAuth token — which the ``x-api-key`` header rejects by
+design — and the resulting 401 killed the whole cycle. A transient CLI
+failure must retry the CLI, not switch to a backend that can never work.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from theswarm.tools.claude import (
+    ClaudeCLI,
+    ClaudeResult,
+    _api_backend_viable,
+    _CLIUnavailable,
+)
+
+
+# ── _api_backend_viable ────────────────────────────────────────────────
+
+
+def test_oauth_token_is_not_viable_for_api(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-oat01-abc123")
+    assert _api_backend_viable() is False
+
+
+def test_real_api_key_is_viable(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-abc123")
+    assert _api_backend_viable() is True
+
+
+def test_missing_key_is_not_viable(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert _api_backend_viable() is False
+
+
+def test_blank_key_is_not_viable(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+    assert _api_backend_viable() is False
+
+
+# ── run() routing ──────────────────────────────────────────────────────
+
+
+async def test_cli_failure_retries_cli_when_api_not_viable(monkeypatch):
+    """With an OAuth token, a transient CLI failure retries the CLI."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-oat01-abc123")
+    monkeypatch.delenv("SWARM_CLAUDE_BACKEND", raising=False)
+
+    cli = ClaudeCLI(model="haiku")
+    calls = 0
+
+    async def flaky_cli(*_a, **_kw):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _CLIUnavailable("CLI timed out after 180s")
+        return ClaudeResult(text="recovered", backend="cli")
+
+    api_mock = AsyncMock()
+    with patch.object(cli, "_run_cli", side_effect=flaky_cli), \
+         patch.object(cli, "_run_api", api_mock):
+        result = await cli.run("hi")
+
+    assert result.text == "recovered"
+    assert calls == 2
+    api_mock.assert_not_awaited()  # never touched the unusable API path
+
+
+async def test_persistent_cli_failure_surfaces_cli_error_not_401(monkeypatch):
+    """Two CLI failures raise the CLI's own error, never an opaque 401."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-oat01-abc123")
+    monkeypatch.delenv("SWARM_CLAUDE_BACKEND", raising=False)
+
+    cli = ClaudeCLI(model="haiku")
+    api_mock = AsyncMock()
+
+    with patch.object(cli, "_run_cli", side_effect=_CLIUnavailable("exit 1: boom")), \
+         patch.object(cli, "_run_api", api_mock):
+        with pytest.raises(RuntimeError, match="CLI failed twice"):
+            await cli.run("hi")
+
+    api_mock.assert_not_awaited()
+
+
+async def test_cli_failure_falls_back_when_api_key_is_real(monkeypatch):
+    """A genuine API key keeps the original fallback behaviour."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-abc123")
+    monkeypatch.delenv("SWARM_CLAUDE_BACKEND", raising=False)
+
+    cli = ClaudeCLI(model="haiku")
+    api_mock = AsyncMock(return_value=ClaudeResult(text="from api", backend="api"))
+
+    with patch.object(cli, "_run_cli", side_effect=_CLIUnavailable("exit 1")), \
+         patch.object(cli, "_run_api", api_mock):
+        result = await cli.run("hi")
+
+    assert result.text == "from api"
+    api_mock.assert_awaited_once()
+
+
+async def test_forced_api_mode_still_uses_api(monkeypatch):
+    """SWARM_CLAUDE_BACKEND=api is explicit — the viability check must not veto it."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-oat01-abc123")
+    monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "api")
+
+    cli = ClaudeCLI(model="haiku")
+    api_mock = AsyncMock(return_value=ClaudeResult(text="forced", backend="api"))
+    cli_mock = AsyncMock()
+
+    with patch.object(cli, "_run_cli", cli_mock), patch.object(cli, "_run_api", api_mock):
+        result = await cli.run("hi")
+
+    assert result.text == "forced"
+    cli_mock.assert_not_awaited()

--- a/tests/test_dev_ralph_loop_counter.py
+++ b/tests/test_dev_ralph_loop_counter.py
@@ -1,0 +1,57 @@
+"""The Ralph Loop retry counter must actually increment.
+
+Prod repro (cycle 65ab4b0fdf3e): ``retry_count`` was returned by
+``retry_implement`` but absent from the ``AgentState`` TypedDict, so
+LangGraph dropped it on every state merge. ``_should_retry`` always read 0
+and the dev loop retried forever — the logs show ``retrying (1/2)`` four
+times in a row — until the 8-minute phase timeout killed it, burning ~$1
+of tokens per iteration.
+"""
+
+from __future__ import annotations
+
+from theswarm.agents.dev import _should_retry
+from theswarm.config import AgentState
+
+
+def test_agent_state_declares_retry_fields():
+    """Without these keys LangGraph silently discards the counter."""
+    annotations = AgentState.__annotations__
+    assert "retry_count" in annotations
+    assert "max_dev_retries" in annotations
+
+
+def test_retry_until_budget_then_proceed():
+    """The routing must stop retrying once the budget is spent."""
+    assert _should_retry({"tests_passed": False, "retry_count": 0, "max_dev_retries": 2}) == "retry"
+    assert _should_retry({"tests_passed": False, "retry_count": 1, "max_dev_retries": 2}) == "retry"
+    # Budget exhausted — proceed to the PR check instead of looping forever
+    assert _should_retry({"tests_passed": False, "retry_count": 2, "max_dev_retries": 2}) == "check_pr"
+    assert _should_retry({"tests_passed": False, "retry_count": 9, "max_dev_retries": 2}) == "check_pr"
+
+
+def test_passing_tests_skip_retries():
+    assert _should_retry({"tests_passed": True, "retry_count": 0, "max_dev_retries": 2}) == "check_pr"
+
+
+def test_zero_retry_budget_never_retries():
+    assert _should_retry({"tests_passed": False, "retry_count": 0, "max_dev_retries": 0}) == "check_pr"
+
+
+async def test_retry_implement_increments_counter():
+    """Stub mode still has to advance the counter, or the loop never ends."""
+    from theswarm.agents.dev import retry_implement
+
+    state: AgentState = {"retry_count": 1, "task": None, "claude": None, "workspace": None}
+    result = await retry_implement(state)
+    assert result["retry_count"] == 2
+
+
+def test_base_state_carries_configured_retry_budget():
+    """CycleConfig.max_dev_retries must reach the dev graph."""
+    from theswarm.config import CycleConfig
+    from theswarm.cycle import _build_base_state
+
+    config = CycleConfig(github_repo="")
+    config.max_dev_retries = 4
+    assert _build_base_state(config)["max_dev_retries"] == 4

--- a/tests/test_tools_claude.py
+++ b/tests/test_tools_claude.py
@@ -11,18 +11,18 @@ class TestEstimateCost:
     def test_sonnet_cost(self):
         # 1M input + 1M output: input $3.00 + output $15.00 = $18.00
         # With 1000 tokens: 3.0 * 1000 / 1_000_000 + 15.0 * 1000 / 1_000_000
-        cost = _estimate_cost("claude-sonnet-4-20250514", 1_000_000, 1_000_000)
+        cost = _estimate_cost("claude-sonnet-5", 1_000_000, 1_000_000)
         assert cost == pytest.approx(18.0, abs=0.01)
 
     def test_opus_cost(self):
-        # 1M input + 1M output: input $15.00 + output $75.00 = $90.00
-        cost = _estimate_cost("claude-opus-4-20250514", 1_000_000, 1_000_000)
-        assert cost == pytest.approx(90.0, abs=0.01)
+        # 1M input + 1M output: input $5.00 + output $25.00 = $30.00
+        cost = _estimate_cost("claude-opus-5", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(30.0, abs=0.01)
 
     def test_haiku_cost(self):
-        # 1M input + 1M output: input $0.80 + output $4.00 = $4.80
-        cost = _estimate_cost("claude-haiku-4-5-20251001", 1_000_000, 1_000_000)
-        assert cost == pytest.approx(4.80, abs=0.01)
+        # 1M input + 1M output: input $1.00 + output $5.00 = $6.00
+        cost = _estimate_cost("claude-haiku-4-5", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(6.00, abs=0.01)
 
     def test_unknown_model_uses_default_rates(self):
         # Default rates: input=3.0, output=15.0 (same as sonnet)
@@ -30,32 +30,32 @@ class TestEstimateCost:
         assert cost == pytest.approx(18.0, abs=0.01)
 
     def test_zero_tokens(self):
-        cost = _estimate_cost("claude-sonnet-4-20250514", 0, 0)
+        cost = _estimate_cost("claude-sonnet-5", 0, 0)
         assert cost == 0.0
 
     def test_large_token_count(self):
         # 1M input tokens for sonnet: 3.0 * 1M / 1M = $3.00
         # 1M output tokens for sonnet: 15.0 * 1M / 1M = $15.00
-        cost = _estimate_cost("claude-sonnet-4-20250514", 1_000_000, 1_000_000)
+        cost = _estimate_cost("claude-sonnet-5", 1_000_000, 1_000_000)
         assert cost == pytest.approx(18.0, abs=0.01)
 
 
 class TestResolveModel:
     def test_sonnet_short_name(self):
         cli = ClaudeCLI(model="sonnet")
-        assert cli._resolve_model() == "claude-sonnet-4-20250514"
+        assert cli._resolve_model() == "claude-sonnet-5"
 
     def test_opus_short_name(self):
         cli = ClaudeCLI(model="opus")
-        assert cli._resolve_model() == "claude-opus-4-20250514"
+        assert cli._resolve_model() == "claude-opus-5"
 
     def test_haiku_short_name(self):
         cli = ClaudeCLI(model="haiku")
-        assert cli._resolve_model() == "claude-haiku-4-5-20251001"
+        assert cli._resolve_model() == "claude-haiku-4-5"
 
     def test_full_model_id_passthrough(self):
-        cli = ClaudeCLI(model="claude-sonnet-4-20250514")
-        assert cli._resolve_model() == "claude-sonnet-4-20250514"
+        cli = ClaudeCLI(model="claude-sonnet-5")
+        assert cli._resolve_model() == "claude-sonnet-5"
 
     def test_unknown_model_passthrough(self):
         cli = ClaudeCLI(model="my-custom-model")
@@ -79,11 +79,11 @@ class TestClaudeResult:
             output_tokens=200,
             total_tokens=700,
             cost_usd=0.0045,
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-5",
         )
         assert result.text == "response"
         assert result.input_tokens == 500
         assert result.output_tokens == 200
         assert result.total_tokens == 700
         assert result.cost_usd == pytest.approx(0.0045)
-        assert result.model == "claude-sonnet-4-20250514"
+        assert result.model == "claude-sonnet-5"

--- a/tests/test_tools_claude_run.py
+++ b/tests/test_tools_claude_run.py
@@ -31,7 +31,7 @@ async def test_run_basic():
     assert result.output_tokens == 50
     assert result.total_tokens == 150
     assert result.cost_usd > 0
-    assert result.model == "claude-sonnet-4-20250514"
+    assert result.model == "claude-sonnet-5"
 
 
 async def test_run_with_workdir():


### PR DESCRIPTION
Found by running a real cycle on concert-tour-app (65ab4b0fdf3e). **The git-identity fix from #10 works** — the log shows `Committed: feat: Create MIT LICENSE file at repository root`, the exact multi-line message that died with rc=128 in April. But the run still failed, for two reasons that were hiding behind it.

### 1. The API fallback could never succeed, and killed the cycle

The Claude CLI hung transiently (the QA phase had three uvicorn servers running alongside it). Auto mode fell back to the Messages API — where this deployment's `ANTHROPIC_API_KEY` is an `sk-ant-oat` OAuth token that the `x-api-key` header rejects **by design** (already documented in a comment in `claude.py`). So a recoverable hiccup became a fatal 401.

`_api_backend_viable()` now gates the fallback: with an OAuth token or no key, retry the CLI once and raise the CLI's real error instead of an opaque auth failure. A genuine `sk-ant-api` key keeps the old behaviour, and `SWARM_CLAUDE_BACKEND=api` is still honoured explicitly.

### 2. The Ralph Loop never counted its retries

`retry_count` was returned by `retry_implement` but absent from the `AgentState` TypedDict, so LangGraph dropped it on every merge. `_should_retry` always read 0 → the dev loop retried forever. The logs show `retrying (1/2)` four times running, ~8 minutes and roughly $1 of tokens, until the phase timeout fired (that timeout is from #10 — it worked, but it was papering over this).

Declared `retry_count` and `max_dev_retries` in the schema, and wired `CycleConfig.max_dev_retries` into the base state so the configured budget is actually used.

## Test plan

- [x] `_api_backend_viable`: OAuth token / missing / blank → not viable; real key → viable
- [x] Transient CLI failure retries the CLI and never touches the API when the key is OAuth
- [x] Persistent CLI failure raises the CLI error, not a 401
- [x] Real API key still falls back; forced `api` mode still bypasses the CLI
- [x] Retry routing stops at the budget; `retry_implement` increments; base state carries the configured budget
- [x] Full suite: 2185 passing
- [ ] Post-deploy: re-run a real cycle and confirm a PR is opened