### PR TITLE
fix(dev): install requirements once per iteration, not once per retry

### DIFF
--- a/src/theswarm/agents/dev.py
+++ b/src/theswarm/agents/dev.py
@@ -178,9 +178,13 @@ async def run_quality_gates(state: AgentState) -> dict:
         return stub_result(Role.DEV, "run_quality_gates",
                            "run pytest on workspace")
 
-    # Install dependencies if requirements.txt exists
+    # Install dependencies once per dev iteration. The Ralph Loop re-runs this
+    # node after every retry, and a failing install burns its full timeout each
+    # time — three attempts ate 360s of the 480s phase budget in prod cycle
+    # 1d816463e34b, so the iteration died before it could open its PR.
+    deps_installed = state.get("deps_installed", False)
     req_file = os.path.join(workspace, "requirements.txt")
-    if os.path.isfile(req_file):
+    if not deps_installed and os.path.isfile(req_file):
         install_result = await claude.run_tests(
             workspace, ["pip", "install", "-q", "-r", "requirements.txt"], timeout=120,
         )
@@ -200,6 +204,7 @@ async def run_quality_gates(state: AgentState) -> dict:
     return {
         "tests_passed": test_result["passed"],
         "test_output": test_result["output"][-2000:],
+        "deps_installed": True,
         "tokens_used": 0,
     }
 

--- a/src/theswarm/config.py
+++ b/src/theswarm/config.py
@@ -49,6 +49,7 @@ class AgentState(TypedDict, total=False):
     # retried until the phase timeout (prod cycle 65ab4b0fdf3e).
     retry_count: int
     max_dev_retries: int
+    deps_installed: bool  # requirements.txt installed once per dev iteration
     blockers: list[dict]
     pr: dict | None
     # TechLead-specific

--- a/tests/test_dev_deps_install_once.py
+++ b/tests/test_dev_deps_install_once.py
@@ -1,0 +1,76 @@
+"""Dependencies install once per dev iteration, not once per retry.
+
+Prod repro (cycle 1d816463e34b): ``pip install -r requirements.txt`` hangs
+for its full 120s timeout in the deploy container and always fails. The
+Ralph Loop re-enters ``run_quality_gates`` after every retry, so three
+identical installs ate 360s of the 480s phase budget and the phase timeout
+killed the iteration before ``open_pull_request`` could run — no PR, even
+though the commit had landed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from theswarm.agents.dev import run_quality_gates
+
+
+class _FakeClaude:
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+
+    async def run_tests(self, workdir, command, *, timeout=300):
+        self.commands.append(list(command))
+        return {"passed": False, "output": "boom", "exit_code": 1}
+
+
+def _write_requirements(tmp_path):
+    (tmp_path / "requirements.txt").write_text("fastapi\n")
+    return str(tmp_path)
+
+
+def _install_calls(claude: _FakeClaude) -> list[list[str]]:
+    return [c for c in claude.commands if "pip" in c]
+
+
+async def test_first_run_installs_dependencies(tmp_path):
+    claude = _FakeClaude()
+    state = {"task": {"number": 1}, "workspace": _write_requirements(tmp_path), "claude": claude}
+
+    result = await run_quality_gates(state)
+
+    assert len(_install_calls(claude)) == 1
+    assert result["deps_installed"] is True
+
+
+async def test_retry_run_skips_reinstall(tmp_path):
+    """The expensive, always-failing install must not repeat on a retry."""
+    claude = _FakeClaude()
+    state = {
+        "task": {"number": 1},
+        "workspace": _write_requirements(tmp_path),
+        "claude": claude,
+        "deps_installed": True,
+    }
+
+    result = await run_quality_gates(state)
+
+    assert _install_calls(claude) == []
+    assert result["deps_installed"] is True
+    # pytest still runs — only the install is skipped
+    assert any("pytest" in c for c in claude.commands)
+
+
+async def test_no_requirements_file_skips_install(tmp_path):
+    claude = _FakeClaude()
+    state = {"task": {"number": 1}, "workspace": str(tmp_path), "claude": claude}
+
+    await run_quality_gates(state)
+
+    assert _install_calls(claude) == []
+
+
+async def test_deps_installed_is_declared_in_state():
+    from theswarm.config import AgentState
+
+    assert "deps_installed" in AgentState.__annotations__


### PR DESCRIPTION
Third round of live validation on concert-tour-app (cycle 1d816463e34b). Two things from #13 are confirmed working in production:

- The Ralph Loop counter now increments — logs show `retrying (1/2)` then `retrying (2/2)` instead of `(1/2)` forever.
- The commit lands: `Committed: feat: Create MIT LICENSE file at repository root`.

But the iteration still died before opening its PR, for a reason the endless loop had been masking.

### The 120s install, three times over

`pip install -q -r requirements.txt` hangs for its full 120s timeout in the deploy container and always fails. `run_quality_gates` is re-entered on every Ralph Loop retry, so it ran three identical doomed installs:

| | start | end | elapsed |
|---|---|---|---|
| install 1 | 18:15:52 | 18:17:53 | 121s |
| install 2 | 18:18:53 | 18:20:53 | 120s |
| install 3 | 18:22:02 | — | killed by phase timeout at 18:22:20 |

That is 360s of a 480s phase budget spent re-running the same failure, and the `dev_iter` timeout fired during the third one — so `open_pull_request` was never reached.

Tracking `deps_installed` in the graph state makes the install run once per dev iteration. Tests still run on every pass; only the install is skipped. A failing suite now reaches `open_pull_request` and produces a PR flagged *needs review*, which is the intended behaviour.

## Test plan

- [x] First pass installs; retry pass skips the install but still runs pytest
- [x] No `requirements.txt` → no install attempted
- [x] `deps_installed` declared in `AgentState` (enforced by the schema guard from #13)
- [x] Full suite: 2191 passing
- [ ] Post-deploy: re-run the cycle and confirm a PR is opened

## Still open, needs your call

The QA phase cannot work in production: `playwright` sits in the `dev` dependency group while the Dockerfile builds with `uv sync --no-dev`, so every screenshot and video fails with `No module named 'playwright'` and the demo report is always `red`. Fixing it means shipping Playwright plus its browsers in the image (~400MB) — a dependency decision, so I have not made it.