### PR TITLE
fix(git): authenticate push, and keep the token out of logs and .git/config

### DIFF
--- a/src/theswarm/agents/dev.py
+++ b/src/theswarm/agents/dev.py
@@ -178,9 +178,13 @@ async def run_quality_gates(state: AgentState) -> dict:
         return stub_result(Role.DEV, "run_quality_gates",
                            "run pytest on workspace")
 
-    # Install dependencies if requirements.txt exists
+    # Install dependencies once per dev iteration. The Ralph Loop re-runs this
+    # node after every retry, and a failing install burns its full timeout each
+    # time — three attempts ate 360s of the 480s phase budget in prod cycle
+    # 1d816463e34b, so the iteration died before it could open its PR.
+    deps_installed = state.get("deps_installed", False)
     req_file = os.path.join(workspace, "requirements.txt")
-    if os.path.isfile(req_file):
+    if not deps_installed and os.path.isfile(req_file):
         install_result = await claude.run_tests(
             workspace, ["pip", "install", "-q", "-r", "requirements.txt"], timeout=120,
         )
@@ -200,6 +204,7 @@ async def run_quality_gates(state: AgentState) -> dict:
     return {
         "tests_passed": test_result["passed"],
         "test_output": test_result["output"][-2000:],
+        "deps_installed": True,
         "tokens_used": 0,
     }
 

--- a/src/theswarm/config.py
+++ b/src/theswarm/config.py
@@ -49,6 +49,7 @@ class AgentState(TypedDict, total=False):
     # retried until the phase timeout (prod cycle 65ab4b0fdf3e).
     retry_count: int
     max_dev_retries: int
+    deps_installed: bool  # requirements.txt installed once per dev iteration
     blockers: list[dict]
     pr: dict | None
     # TechLead-specific

--- a/src/theswarm/cycle.py
+++ b/src/theswarm/cycle.py
@@ -170,9 +170,11 @@ async def _pull_latest(config: CycleConfig) -> None:
     if not config.is_real_mode:
         return
 
-    from theswarm.tools.git import _run_git
+    from theswarm.tools.git import _auth_args, _run_git
     await _run_git("checkout", "main", cwd=config.workspace_dir, check=False)
-    await _run_git("pull", "--ff-only", cwd=config.workspace_dir, check=False)
+    await _run_git(
+        *_auth_args(), "pull", "--ff-only", cwd=config.workspace_dir, check=False,
+    )
 
 
 async def run_daily_cycle(

--- a/src/theswarm/tools/git.py
+++ b/src/theswarm/tools/git.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import os
+import re
 import shutil
 
 log = logging.getLogger(__name__)
@@ -47,13 +49,26 @@ async def _run_git(
     except asyncio.TimeoutError:
         proc.kill()
         raise RuntimeError(
-            f"git {' '.join(args)} timed out after {timeout:.0f}s"
+            f"git {redact(' '.join(args))} timed out after {timeout:.0f}s"
         ) from None
     if check and proc.returncode != 0:
         raise RuntimeError(
-            f"git {' '.join(args)} failed (rc={proc.returncode}): {stderr.decode()[:500]}"
+            f"git {redact(' '.join(args))} failed (rc={proc.returncode}): "
+            f"{redact(stderr.decode())[:500]}"
         )
     return stdout.decode().strip()
+
+
+_EXTRAHEADER_RE = re.compile(r"(extraheader=AUTHORIZATION: basic )\S+", re.IGNORECASE)
+
+
+def redact(text: str) -> str:
+    """Strip credentials from anything headed for a log or an exception."""
+    cleaned = _EXTRAHEADER_RE.sub(r"\1***", text)
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if token:
+        cleaned = cleaned.replace(token, "***")
+    return cleaned
 
 
 def _identity_args() -> list[str]:
@@ -63,24 +78,43 @@ def _identity_args() -> list[str]:
     return ["-c", f"user.name={name}", "-c", f"user.email={email}"]
 
 
+def _auth_args() -> list[str]:
+    """GitHub credentials for network operations over HTTPS.
+
+    Passed per command with ``-c`` rather than baked into the remote URL, so
+    the token never lands in the workspace's ``.git/config`` where later
+    commands (and anything else in the container) could read it back.
+
+    Without this, ``git push`` has no credentials at all: it used to block on
+    git's username prompt until the phase timeout killed it, which is why
+    every April cycle opened zero PRs. With prompts disabled it now fails
+    fast instead — this supplies the credentials it was always missing.
+    """
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        return []
+    basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    return ["-c", f"http.https://github.com/.extraheader=AUTHORIZATION: basic {basic}"]
+
+
 async def clone_repo(repo_url: str, dest: str) -> str:
     """Clone a repo to dest. If dest already exists, pull instead."""
     if os.path.isdir(os.path.join(dest, ".git")):
         log.info("Repo already cloned at %s — pulling latest", dest)
         await _run_git("checkout", "main", cwd=dest, check=False)
-        await _run_git("pull", "--ff-only", cwd=dest, check=False)
+        await _run_git(*_auth_args(), "pull", "--ff-only", cwd=dest, check=False)
         return dest
 
     log.info("Cloning %s → %s", repo_url, dest)
     os.makedirs(os.path.dirname(dest), exist_ok=True)
-    await _run_git("clone", repo_url, dest)
+    await _run_git(*_auth_args(), "clone", repo_url, dest)
     return dest
 
 
 async def create_branch(workdir: str, branch_name: str, base: str = "main") -> None:
     """Create and checkout a new branch from base."""
     await _run_git("checkout", base, cwd=workdir)
-    await _run_git("pull", "--ff-only", cwd=workdir, check=False)
+    await _run_git(*_auth_args(), "pull", "--ff-only", cwd=workdir, check=False)
     await _run_git("checkout", "-b", branch_name, cwd=workdir)
     log.info("Created branch %s from %s", branch_name, base)
 
@@ -114,7 +148,7 @@ async def commit_all(workdir: str, message: str) -> bool:
 
 async def push_branch(workdir: str, branch_name: str) -> None:
     """Push branch to origin."""
-    await _run_git("push", "-u", "origin", branch_name, cwd=workdir)
+    await _run_git(*_auth_args(), "push", "-u", "origin", branch_name, cwd=workdir)
     log.info("Pushed branch %s", branch_name)
 
 

--- a/tests/test_dev_deps_install_once.py
+++ b/tests/test_dev_deps_install_once.py
@@ -1,0 +1,76 @@
+"""Dependencies install once per dev iteration, not once per retry.
+
+Prod repro (cycle 1d816463e34b): ``pip install -r requirements.txt`` hangs
+for its full 120s timeout in the deploy container and always fails. The
+Ralph Loop re-enters ``run_quality_gates`` after every retry, so three
+identical installs ate 360s of the 480s phase budget and the phase timeout
+killed the iteration before ``open_pull_request`` could run — no PR, even
+though the commit had landed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from theswarm.agents.dev import run_quality_gates
+
+
+class _FakeClaude:
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+
+    async def run_tests(self, workdir, command, *, timeout=300):
+        self.commands.append(list(command))
+        return {"passed": False, "output": "boom", "exit_code": 1}
+
+
+def _write_requirements(tmp_path):
+    (tmp_path / "requirements.txt").write_text("fastapi\n")
+    return str(tmp_path)
+
+
+def _install_calls(claude: _FakeClaude) -> list[list[str]]:
+    return [c for c in claude.commands if "pip" in c]
+
+
+async def test_first_run_installs_dependencies(tmp_path):
+    claude = _FakeClaude()
+    state = {"task": {"number": 1}, "workspace": _write_requirements(tmp_path), "claude": claude}
+
+    result = await run_quality_gates(state)
+
+    assert len(_install_calls(claude)) == 1
+    assert result["deps_installed"] is True
+
+
+async def test_retry_run_skips_reinstall(tmp_path):
+    """The expensive, always-failing install must not repeat on a retry."""
+    claude = _FakeClaude()
+    state = {
+        "task": {"number": 1},
+        "workspace": _write_requirements(tmp_path),
+        "claude": claude,
+        "deps_installed": True,
+    }
+
+    result = await run_quality_gates(state)
+
+    assert _install_calls(claude) == []
+    assert result["deps_installed"] is True
+    # pytest still runs — only the install is skipped
+    assert any("pytest" in c for c in claude.commands)
+
+
+async def test_no_requirements_file_skips_install(tmp_path):
+    claude = _FakeClaude()
+    state = {"task": {"number": 1}, "workspace": str(tmp_path), "claude": claude}
+
+    await run_quality_gates(state)
+
+    assert _install_calls(claude) == []
+
+
+async def test_deps_installed_is_declared_in_state():
+    from theswarm.config import AgentState
+
+    assert "deps_installed" in AgentState.__annotations__

--- a/tests/test_git_push_auth.py
+++ b/tests/test_git_push_auth.py
@@ -1,0 +1,139 @@
+"""git push must carry credentials, and they must never leak.
+
+Prod repro (cycle b35b55ef832f): once the dev loop finally reached
+``open_pull_request``, the push died with ``could not read Username for
+'https://github.com': terminal prompts disabled``. The clone URL carries no
+credentials, so the push never had any — before prompts were disabled it
+blocked on git's username prompt until the phase timeout, which is why
+every April cycle opened zero PRs.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from theswarm.tools.git import _auth_args, _run_git, clone_repo, push_branch, redact
+
+TOKEN = "ghp_secrettokenvalue123"
+EXPECTED_BASIC = base64.b64encode(f"x-access-token:{TOKEN}".encode()).decode()
+
+
+@pytest.fixture()
+def mock_subprocess(mocker):
+    proc = AsyncMock()
+    proc.returncode = 0
+    proc.communicate = AsyncMock(return_value=(b"", b""))
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+    return proc
+
+
+# ── _auth_args ─────────────────────────────────────────────────────────
+
+
+def test_auth_args_build_basic_header(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", TOKEN)
+    args = _auth_args()
+    assert args[0] == "-c"
+    assert args[1] == (
+        f"http.https://github.com/.extraheader=AUTHORIZATION: basic {EXPECTED_BASIC}"
+    )
+
+
+def test_auth_args_empty_without_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert _auth_args() == []
+
+
+# ── push ───────────────────────────────────────────────────────────────
+
+
+async def test_push_carries_credentials(mock_subprocess, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", TOKEN)
+    import asyncio
+
+    await push_branch("/tmp/repo", "feat/x")
+
+    args = asyncio.create_subprocess_exec.call_args.args
+    assert "-c" in args
+    assert any("extraheader=AUTHORIZATION: basic" in a for a in args)
+    # The -c flag must precede the subcommand, or git rejects it
+    assert args.index("-c") < args.index("push")
+
+
+async def test_clone_carries_credentials(mock_subprocess, mocker, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", TOKEN)
+    mocker.patch("os.path.isdir", return_value=False)
+    mocker.patch("os.makedirs")
+    import asyncio
+
+    await clone_repo("https://github.com/o/r.git", "/tmp/repo")
+
+    args = asyncio.create_subprocess_exec.call_args.args
+    assert any("extraheader=AUTHORIZATION: basic" in a for a in args)
+
+
+async def test_push_without_token_sends_no_auth_flag(mock_subprocess, monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    import asyncio
+
+    await push_branch("/tmp/repo", "feat/x")
+
+    assert asyncio.create_subprocess_exec.call_args.args == (
+        "git", "push", "-u", "origin", "feat/x",
+    )
+
+
+# ── redaction ──────────────────────────────────────────────────────────
+
+
+def test_redact_masks_basic_header(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    text = f"http.https://github.com/.extraheader=AUTHORIZATION: basic {EXPECTED_BASIC}"
+    assert EXPECTED_BASIC not in redact(text)
+    assert "***" in redact(text)
+
+
+def test_redact_masks_raw_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", TOKEN)
+    assert TOKEN not in redact(f"remote: https://{TOKEN}@github.com/o/r")
+
+
+async def test_failure_message_does_not_leak_credentials(mocker, monkeypatch):
+    """A failing authenticated push must not print the token in its exception."""
+    monkeypatch.setenv("GITHUB_TOKEN", TOKEN)
+    proc = AsyncMock()
+    proc.returncode = 128
+    proc.communicate = AsyncMock(return_value=(b"", f"denied for {TOKEN}".encode()))
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await push_branch("/tmp/repo", "feat/x")
+
+    message = str(excinfo.value)
+    assert TOKEN not in message
+    assert EXPECTED_BASIC not in message
+
+
+async def test_timeout_message_does_not_leak_credentials(mocker, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", TOKEN)
+    import asyncio as _asyncio
+
+    proc = AsyncMock()
+    proc.returncode = None
+
+    async def hang():
+        await _asyncio.sleep(30)
+
+    proc.communicate = hang
+    proc.kill = lambda: None
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await _run_git(*_auth_args(), "push", timeout=0.05)
+
+    assert TOKEN not in str(excinfo.value)
+    assert EXPECTED_BASIC not in str(excinfo.value)


### PR DESCRIPTION
This is the last link in the chain. Cycle b35b55ef832f reached `open_pull_request` for the first time — the `deps_installed` fix from #14 freed enough phase budget — and the push died immediately:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

`repo_clone_url` is a bare `https://github.com/{repo}.git`. Cloning works because the repo is public; **the push never had credentials at all**. Before `GIT_TERMINAL_PROMPT=0` (from #10) it blocked on git's username prompt until the phase timeout — it could neither succeed nor fail. That is why all ten April cycles opened zero PRs, and why the symptom read as a hang rather than an auth error.

### What changed

Credentials are supplied per command via `-c http.https://github.com/.extraheader=AUTHORIZATION: basic …` on clone, pull and push, rather than baked into the remote URL. The token is therefore never written to the workspace's `.git/config`, where every later command in the cycle — and anything else in the container — could read it back.

Because `_run_git` echoes argv and stderr in its exceptions, a `redact()` pass masks both the basic-auth header and the raw `GITHUB_TOKEN` on every failure and timeout path.

### Progress across the validation cycles

| Cycle | Reached | Blocked by |
|---|---|---|
| 65ab4b0fdf3e | commit | Ralph Loop never counted (#13) |
| 1d816463e34b | retries bounded | three 120s installs ate the phase budget (#14) |
| b35b55ef832f | `open_pull_request` | **push had no credentials** ← this PR |

## Test plan

- [x] `_auth_args` builds the basic header; empty without `GITHUB_TOKEN`
- [x] clone and push carry the flag, and `-c` precedes the subcommand
- [x] No token → plain argv, unchanged behaviour
- [x] `redact` masks the header and the raw token
- [x] Failure and timeout exceptions leak neither
- [x] Full suite: 2200 passing
- [ ] Post-deploy: re-run the cycle and confirm a PR appears on concert-tour-app