### PR TITLE
feat(qa): ship Playwright in the image; fix(dev): one interpreter for install and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,22 @@ COPY --from=builder --chown=botuser:botuser /app/src /app/src
 COPY --from=builder --chown=botuser:botuser /app/docs /app/docs
 COPY --from=builder --chown=botuser:botuser /app/theswarm.yaml* /app/
 
+# Chromium's shared libraries, for the QA agent's screenshot and video
+# capture. Needs root, so it runs before the USER switch; the browser itself
+# is fetched afterwards as botuser.
+RUN /app/.venv/bin/playwright install-deps chromium \
+    && rm -rf /var/lib/apt/lists/*
+
 USER botuser
 
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1
+
+# Only the headless shell, which is what `chromium.launch(headless=True)`
+# actually executes — the full Chromium build is ~800MB more for a UI this
+# image never opens. Installed as botuser so it lands in the cache of the
+# user the app runs as.
+RUN playwright install chromium-headless-shell
 
 EXPOSE 8091
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,12 @@ dependencies = [
     "textual>=1.0",
     "imageio-ffmpeg>=0.5",
     "cryptography>=42.0",
+    # Runtime dependency: the QA agent captures demo screenshots and videos of
+    # the target app via PlaywrightRecorder. It lived in the dev group while
+    # the image built with --no-dev, so every capture failed in production
+    # with "No module named 'playwright'". The browser binary is installed
+    # separately in the Dockerfile.
+    "playwright>=1.58.0",
 ]
 
 [dependency-groups]
@@ -32,7 +38,6 @@ dev = [
     "respx>=0.22",
     "pytest-mock>=3.14",
     "pytest-cov>=7.1.0",
-    "playwright>=1.58.0",
     "pytest-playwright>=0.7.2",
 ]
 

--- a/src/theswarm/agents/base.py
+++ b/src/theswarm/agents/base.py
@@ -105,6 +105,28 @@ def _infer_role(phase: str) -> str | None:
     return phase_role_map.get(phase)
 
 
+def find_system_python() -> str:
+    """Interpreter used to install and run the *target* project's code.
+
+    Deliberately not TheSwarm's own venv: the target project's dependencies
+    must not be installed into it, and the venv ignores the user site-packages
+    directory that a non-root ``pip install`` writes to. Dev and QA must agree
+    on this — installing with one interpreter and testing with another means
+    the tests never see the dependencies (prod cycle 882694d44248).
+    """
+    import os
+    import sys as _sys
+
+    venv_prefix = _sys.prefix
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if venv_prefix in entry:
+            continue
+        candidate = os.path.join(entry, "python3")
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return "python3"
+
+
 def stub_result(role: Role, phase: str, detail: str = "") -> dict[str, Any]:
     """Return a standard stub result for a phase that is not yet implemented."""
     msg = f"[STUB] {role.value}/{phase}: would execute here"

--- a/src/theswarm/agents/dev.py
+++ b/src/theswarm/agents/dev.py
@@ -14,10 +14,14 @@ from datetime import datetime
 
 from langgraph.graph import END, StateGraph
 
-from theswarm.agents.base import load_context, stub_result
+from theswarm.agents.base import find_system_python, load_context, stub_result
 from theswarm.config import AgentState, Role
 
 log = logging.getLogger(__name__)
+
+# Cold install of a typical FastAPI stack measured 145s in the deploy
+# container, so the previous 120s cap expired every time.
+DEP_INSTALL_TIMEOUT_SECONDS = 300
 
 
 # ── Prompts ─────────────────────────────────────────────────────────────
@@ -178,22 +182,32 @@ async def run_quality_gates(state: AgentState) -> dict:
         return stub_result(Role.DEV, "run_quality_gates",
                            "run pytest on workspace")
 
-    # Install dependencies once per dev iteration. The Ralph Loop re-runs this
-    # node after every retry, and a failing install burns its full timeout each
-    # time — three attempts ate 360s of the 480s phase budget in prod cycle
-    # 1d816463e34b, so the iteration died before it could open its PR.
+    # Both commands must run under the *same* interpreter. A bare `pip`
+    # resolves to the system python while a bare `python` resolves to
+    # TheSwarm's venv, so dependencies landed in the system user site while
+    # pytest ran in a venv that ignores it — the target's tests never saw
+    # them (prod cycle 882694d44248).
+    python = find_system_python()
+
+    # Install once per dev iteration: the Ralph Loop re-enters this node after
+    # every retry, and three cold installs ate 360s of the 480s phase budget
+    # in prod cycle 1d816463e34b.
     deps_installed = state.get("deps_installed", False)
     req_file = os.path.join(workspace, "requirements.txt")
     if not deps_installed and os.path.isfile(req_file):
         install_result = await claude.run_tests(
-            workspace, ["pip", "install", "-q", "-r", "requirements.txt"], timeout=120,
+            workspace,
+            [python, "-m", "pip", "install", "-q", "-r", "requirements.txt"],
+            # A cold install of a typical FastAPI stack measured 145s in the
+            # deploy container, so the old 120s cap always expired.
+            timeout=DEP_INSTALL_TIMEOUT_SECONDS,
         )
         if not install_result["passed"]:
             log.warning("pip install failed:\n%s", install_result["output"][-1000:])
 
     # Run pytest if available
     test_result = await claude.run_tests(
-        workspace, ["python", "-m", "pytest", "tests/", "-v", "--tb=short"], timeout=120,
+        workspace, [python, "-m", "pytest", "tests/", "-v", "--tb=short"], timeout=120,
     )
 
     if test_result["passed"]:

--- a/src/theswarm/agents/qa.py
+++ b/src/theswarm/agents/qa.py
@@ -952,18 +952,14 @@ def build_qa_graph() -> StateGraph:
 
 
 def _find_system_python() -> str:
-    """Find system python3, excluding the current venv."""
-    import os
-    import sys as _sys
+    """Find system python3, excluding the current venv.
 
-    venv_prefix = _sys.prefix
-    for p in os.environ.get("PATH", "").split(os.pathsep):
-        if venv_prefix in p:
-            continue
-        candidate = os.path.join(p, "python3")
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-    return "python3"
+    Thin alias kept for existing call sites; the implementation is shared with
+    the Dev agent so both install and test against the same interpreter.
+    """
+    from theswarm.agents.base import find_system_python
+
+    return find_system_python()
 
 
 def _extract_python_code(text: str) -> str | None:

--- a/src/theswarm/application/services/orphan_reaper.py
+++ b/src/theswarm/application/services/orphan_reaper.py
@@ -18,6 +18,23 @@ log = logging.getLogger(__name__)
 
 DEFAULT_REAP_INTERVAL_SECONDS = 15 * 60
 
+# Grace period on top of the whole-cycle hard timeout before a 'running' row
+# is treated as orphaned. Sits above the timeout so a cycle that is still
+# legitimately executing is never reaped out from under its own task.
+REAP_GRACE_SECONDS = 30 * 60
+
+
+def reap_max_age_seconds() -> int:
+    """Age at which a 'running' cycle row is considered orphaned.
+
+    Single source of truth for the reaper loop and for the readiness banner,
+    so the UI never promises a different cleanup window than the one that
+    actually runs.
+    """
+    from theswarm.api import CYCLE_HARD_TIMEOUT_SECONDS
+
+    return CYCLE_HARD_TIMEOUT_SECONDS + REAP_GRACE_SECONDS
+
 
 class CycleReaperPort(Protocol):
     async def reap_orphans(self, *, max_age_seconds: int) -> int: ...

--- a/src/theswarm/presentation/web/routes/health.py
+++ b/src/theswarm/presentation/web/routes/health.py
@@ -214,11 +214,27 @@ async def readiness(request: Request) -> JSONResponse:
             for c in running:
                 if c.started_at and c.started_at < cutoff:
                     stale.append(c)
-            checks["cycles"] = (
-                {"status": "ok", "detail": f"{len(running)} running, none stale"}
-                if not stale
-                else {"status": "warn", "detail": f"{len(stale)} stale running cycle(s); reaper will clean on next boot"}
-            )
+            if stale:
+                from theswarm.application.services.orphan_reaper import (
+                    DEFAULT_REAP_INTERVAL_SECONDS,
+                    reap_max_age_seconds,
+                )
+
+                reap_hours = reap_max_age_seconds() / 3600
+                every_minutes = round(DEFAULT_REAP_INTERVAL_SECONDS / 60)
+                checks["cycles"] = {
+                    "status": "warn",
+                    "detail": (
+                        f"{len(stale)} stale running cycle(s); the reaper runs every "
+                        f"{every_minutes} min and clears them once they pass "
+                        f"{reap_hours:.1f}h"
+                    ),
+                }
+            else:
+                checks["cycles"] = {
+                    "status": "ok",
+                    "detail": f"{len(running)} running, none stale",
+                }
         except Exception as exc:
             checks["cycles"] = {"status": "warn", "detail": f"could not read cycles: {exc}"}
 

--- a/src/theswarm/presentation/web/server.py
+++ b/src/theswarm/presentation/web/server.py
@@ -481,11 +481,13 @@ async def start_server(
     # Also reap periodically: an in-process hang past the whole-cycle hard
     # timeout must not stay "running" until the next deploy. The age cutoff
     # sits above CYCLE_HARD_TIMEOUT_SECONDS so live cycles are never reaped.
-    from theswarm.api import CYCLE_HARD_TIMEOUT_SECONDS
-    from theswarm.application.services.orphan_reaper import run_orphan_reap_loop
+    from theswarm.application.services.orphan_reaper import (
+        reap_max_age_seconds,
+        run_orphan_reap_loop,
+    )
 
     asyncio.create_task(run_orphan_reap_loop(
-        cycle_repo, max_age_seconds=CYCLE_HARD_TIMEOUT_SECONDS + 1800,
+        cycle_repo, max_age_seconds=reap_max_age_seconds(),
     ))
 
     # Report storage

--- a/tests/presentation/test_readiness_reaper_banner.py
+++ b/tests/presentation/test_readiness_reaper_banner.py
@@ -1,0 +1,47 @@
+"""The stale-cycle banner must describe the reaper that actually runs.
+
+The wording predated the periodic reaper: it promised cleanup "on next boot"
+when the loop now sweeps every 15 minutes. The banner and the loop read the
+same threshold so the UI can never advertise a window that isn't real.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from theswarm.application.services.orphan_reaper import (
+    DEFAULT_REAP_INTERVAL_SECONDS,
+    REAP_GRACE_SECONDS,
+    reap_max_age_seconds,
+)
+from theswarm.presentation.web.routes import health as health_routes
+
+
+def test_reap_window_sits_above_the_cycle_hard_timeout():
+    """A live cycle must never be reaped out from under its own task."""
+    from theswarm.api import CYCLE_HARD_TIMEOUT_SECONDS
+
+    assert reap_max_age_seconds() == CYCLE_HARD_TIMEOUT_SECONDS + REAP_GRACE_SECONDS
+    assert reap_max_age_seconds() > CYCLE_HARD_TIMEOUT_SECONDS
+
+
+def test_server_reaps_with_the_shared_threshold():
+    """The loop must use the same value the banner quotes."""
+    from theswarm.presentation.web import server
+
+    source = inspect.getsource(server.start_server)
+    assert "reap_max_age_seconds()" in source
+    # The old hardcoded grace must be gone, or the two can drift apart
+    assert "CYCLE_HARD_TIMEOUT_SECONDS + 1800" not in source
+
+
+def test_banner_no_longer_promises_next_boot():
+    source = inspect.getsource(health_routes)
+    assert "reaper will clean on next boot" not in source
+
+
+def test_banner_quotes_the_real_interval_and_window():
+    source = inspect.getsource(health_routes)
+    assert "reap_max_age_seconds" in source
+    assert "DEFAULT_REAP_INTERVAL_SECONDS" in source
+    assert DEFAULT_REAP_INTERVAL_SECONDS == 15 * 60

--- a/tests/test_dev_interpreter_consistency.py
+++ b/tests/test_dev_interpreter_consistency.py
@@ -1,0 +1,95 @@
+"""Dev installs and tests with one interpreter, and allows a cold install.
+
+Prod diagnosis (cycle 882694d44248): in the deploy container a bare ``pip``
+resolves to ``/usr/local/bin/pip`` (system python) while a bare ``python``
+resolves to ``/app/.venv/bin/python`` (TheSwarm's venv). Dependencies landed
+in the system user site-packages, which the venv ignores, so the target's
+tests never saw them. The install also measured 145s cold — over the old
+120s cap, so it timed out on every run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from theswarm.agents.dev import DEP_INSTALL_TIMEOUT_SECONDS, run_quality_gates
+
+
+class _RecordingClaude:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], int]] = []
+
+    async def run_tests(self, workdir, command, *, timeout=300):
+        self.calls.append((list(command), timeout))
+        return {"passed": True, "output": "", "exit_code": 0}
+
+
+def _workspace_with_requirements(tmp_path):
+    (tmp_path / "requirements.txt").write_text("fastapi\n")
+    return str(tmp_path)
+
+
+async def test_install_and_test_share_one_interpreter(tmp_path):
+    claude = _RecordingClaude()
+    state = {
+        "task": {"number": 1},
+        "workspace": _workspace_with_requirements(tmp_path),
+        "claude": claude,
+    }
+
+    await run_quality_gates(state)
+
+    install_cmd, _ = claude.calls[0]
+    test_cmd, _ = claude.calls[1]
+    assert install_cmd[1:4] == ["-m", "pip", "install"]
+    assert test_cmd[1:3] == ["-m", "pytest"]
+    # Same interpreter for both — this is the whole point
+    assert install_cmd[0] == test_cmd[0]
+
+
+async def test_no_bare_pip_or_python(tmp_path):
+    """Bare names resolve to different interpreters in the deploy container."""
+    claude = _RecordingClaude()
+    state = {
+        "task": {"number": 1},
+        "workspace": _workspace_with_requirements(tmp_path),
+        "claude": claude,
+    }
+
+    await run_quality_gates(state)
+
+    for command, _ in claude.calls:
+        assert command[0] not in ("pip", "python")
+
+
+async def test_cold_install_gets_enough_time(tmp_path):
+    claude = _RecordingClaude()
+    state = {
+        "task": {"number": 1},
+        "workspace": _workspace_with_requirements(tmp_path),
+        "claude": claude,
+    }
+
+    await run_quality_gates(state)
+
+    _, install_timeout = claude.calls[0]
+    assert install_timeout == DEP_INSTALL_TIMEOUT_SECONDS
+    # A measured 145s cold install must fit comfortably
+    assert install_timeout > 145
+
+
+def test_dev_and_qa_resolve_the_same_interpreter():
+    from theswarm.agents.base import find_system_python
+    from theswarm.agents.qa import _find_system_python
+
+    assert _find_system_python() == find_system_python()
+
+
+def test_find_system_python_skips_the_active_venv():
+    import sys
+
+    from theswarm.agents.base import find_system_python
+
+    resolved = find_system_python()
+    # Must not hand back the venv the app itself runs in
+    assert not resolved.startswith(sys.prefix + "/")

--- a/uv.lock
+++ b/uv.lock
@@ -1459,6 +1459,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "mattermostdriver" },
+    { name = "playwright" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygithub" },
@@ -1472,7 +1473,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1493,6 +1493,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=0.3" },
     { name = "langgraph", specifier = ">=0.2" },
     { name = "mattermostdriver", specifier = ">=7.3" },
+    { name = "playwright", specifier = ">=1.58.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pygithub", specifier = ">=2.0" },
@@ -1506,7 +1507,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "playwright", specifier = ">=1.58.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=7.1.0" },


### PR DESCRIPTION
Three items the last validation cycle surfaced.

### 1. Playwright ships in production

It sat in the `dev` dependency group while the image builds with `uv sync --no-dev`, so every capture failed with `No module named 'playwright'` and the demo report was permanently `red`. It moves to the runtime dependencies and the image now installs the browser.

Only `chromium-headless-shell` is fetched — that is what `chromium.launch(headless=True)` actually executes, and it costs **~630MB less** than the full Chromium build (the `playwright install chromium` layer alone was 972MB). Verified inside the built image, as `botuser`:

```
SCREENSHOT=5276B  VIDEO=3245B
```

Both paths the recorder uses work, so this is not just an import fix.

### 2. `pip install` never worked — two independent causes

**Wrong interpreter.** In the container a bare `pip` resolves to `/usr/local/bin/pip` (system python) while a bare `python` resolves to `/app/.venv/bin/python` (TheSwarm's venv). Dependencies landed in the system user site-packages, which the venv ignores by design — so the target's tests never saw them, even on the runs where the install succeeded.

**Timeout too tight.** A cold install of the target's stack (`fastapi`, `uvicorn[standard]`, `sqlalchemy`, `pydantic`, `pytest`) measured **145s** in the deploy container against a 120s cap:

```
RC=0 elapsed=145s
```

PyPI was always reachable — `pip install --dry-run` succeeded — so this read as a network problem when it was a budget problem.

Both commands now run under the interpreter QA already uses, shared from `agents.base` so the two agents cannot drift apart again, with a 300s install budget.

### 3. Stale-cycle banner

It still promised cleanup *"on next boot"*, wording that predates the periodic reaper from #10. It now quotes the real interval and window, read from the same helper the reaper loop uses.

## Test plan

- [x] Image builds; Playwright launches as `botuser` and produces both a screenshot and a video
- [x] Install and test commands share one interpreter; neither uses a bare `pip`/`python`
- [x] Install budget exceeds the measured 145s cold install
- [x] Dev and QA resolve the same interpreter; it is never the active venv
- [x] Banner no longer says "next boot"; reap window stays above the cycle hard timeout
- [x] Full suite: 2215 passing
- [ ] Post-deploy: run a cycle and confirm screenshots/videos appear and the demo report leaves `red`

Rebased on `main` (`4acaf45`); no overlap with the two in-flight agent branches.