### PR TITLE
fix(dev): reinstall when requirements change; fix(qa): report why a target fails to boot

### DIFF
--- a/src/theswarm/agents/dev.py
+++ b/src/theswarm/agents/dev.py
@@ -7,6 +7,7 @@ In real mode, clones the repo, calls claude CLI to implement, pushes a PR.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import re
@@ -189,12 +190,15 @@ async def run_quality_gates(state: AgentState) -> dict:
     # them (prod cycle 882694d44248).
     python = find_system_python()
 
-    # Install once per dev iteration: the Ralph Loop re-enters this node after
-    # every retry, and three cold installs ate 360s of the 480s phase budget
-    # in prod cycle 1d816463e34b.
-    deps_installed = state.get("deps_installed", False)
+    # Install only when the requirements actually change. The Ralph Loop
+    # re-enters this node after every retry, and three cold installs ate 360s
+    # of the 480s phase budget in prod cycle 1d816463e34b — but a flat "already
+    # installed" flag is wrong too: a retry that adds a missing dependency
+    # needs it installed, which is how cycle 8170b32ca48f kept failing on a
+    # module the retry had just declared.
     req_file = os.path.join(workspace, "requirements.txt")
-    if not deps_installed and os.path.isfile(req_file):
+    fingerprint = _requirements_fingerprint(req_file)
+    if fingerprint and fingerprint != state.get("deps_fingerprint", ""):
         install_result = await claude.run_tests(
             workspace,
             [python, "-m", "pip", "install", "-q", "-r", "requirements.txt"],
@@ -218,7 +222,7 @@ async def run_quality_gates(state: AgentState) -> dict:
     return {
         "tests_passed": test_result["passed"],
         "test_output": test_result["output"][-2000:],
-        "deps_installed": True,
+        "deps_fingerprint": fingerprint,
         "tokens_used": 0,
     }
 
@@ -423,6 +427,20 @@ def _extract_files_from_response(text: str, workspace: str) -> int:
         log.info("Wrote file: %s", filepath)
 
     return files_written
+
+
+def _requirements_fingerprint(req_file: str) -> str:
+    """Content hash of requirements.txt, or "" when there is no file.
+
+    Keyed on content rather than a boolean so a Ralph Loop retry that adds a
+    missing dependency triggers a reinstall, while repeated retries over
+    unchanged requirements still skip the expensive install.
+    """
+    try:
+        with open(req_file, "rb") as handle:
+            return hashlib.sha256(handle.read()).hexdigest()
+    except OSError:
+        return ""
 
 
 def _make_branch_name(task: dict) -> str:

--- a/src/theswarm/agents/qa.py
+++ b/src/theswarm/agents/qa.py
@@ -174,7 +174,9 @@ async def run_unit_tests(state: AgentState) -> dict:
                            "run pytest unit tests")
 
     result = await claude.run_tests(
-        workspace, ["python", "-m", "pytest", "tests/unit/", "-v", "--tb=short"], timeout=120,
+        workspace,
+        [_find_system_python(), "-m", "pytest", "tests/unit/", "-v", "--tb=short"],
+        timeout=120,
     )
 
     output = result["output"]
@@ -242,7 +244,7 @@ async def run_e2e_tests(state: AgentState) -> dict:
     try:
         await wait_for_http_ready(f"http://127.0.0.1:{port}/", timeout=30.0, interval=0.5)
     except ReadinessTimeout as exc:
-        log.warning("QA E2E: %s — running tests anyway", exc)
+        await _log_readiness_failure("QA E2E", server_proc, exc)
 
     e2e_output = ""
     e2e_passed = False
@@ -416,7 +418,7 @@ async def capture_demo_screenshots(state: AgentState) -> dict:
     try:
         await wait_for_http_ready(f"http://127.0.0.1:{port}/", timeout=30.0, interval=0.5)
     except ReadinessTimeout as exc:
-        log.warning("QA screenshots: %s — capturing anyway", exc)
+        await _log_readiness_failure("QA screenshots", server_proc, exc)
 
     recorder = PlaywrightRecorder()
     base_url = f"http://127.0.0.1:{port}"
@@ -558,7 +560,7 @@ async def record_demo_video(state: AgentState) -> dict:
     try:
         await wait_for_http_ready(f"http://127.0.0.1:{port}/", timeout=30.0, interval=0.5)
     except ReadinessTimeout as exc:
-        log.warning("QA video: %s — recording anyway", exc)
+        await _log_readiness_failure("QA video", server_proc, exc)
 
     recorder = PlaywrightRecorder()
     base_url = f"http://127.0.0.1:{port}"
@@ -949,6 +951,35 @@ def build_qa_graph() -> StateGraph:
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────
+
+
+async def _log_readiness_failure(label: str, server_proc, exc: Exception) -> None:
+    """Report *why* the target app never came up.
+
+    The server's output is piped but otherwise never read, so a target that
+    dies on import — a missing dependency, a syntax error — produced only a
+    bare connection-refused with no cause anywhere in the logs (prod cycle
+    8170b32ca48f). Read it back when the process has already exited; if it is
+    still alive, say so rather than blocking on communicate().
+    """
+    import asyncio as _asyncio
+
+    if server_proc.returncode is None:
+        log.warning("%s: %s — server still running but not serving", label, exc)
+        return
+
+    output = ""
+    try:
+        stdout, _ = await _asyncio.wait_for(server_proc.communicate(), timeout=5)
+        output = stdout.decode(errors="replace").strip()[-1500:]
+    except (_asyncio.TimeoutError, ValueError):
+        pass
+
+    log.warning(
+        "%s: %s — server exited rc=%s%s",
+        label, exc, server_proc.returncode,
+        f"\n--- server output ---\n{output}" if output else " (no output captured)",
+    )
 
 
 def _find_system_python() -> str:

--- a/src/theswarm/config.py
+++ b/src/theswarm/config.py
@@ -49,7 +49,7 @@ class AgentState(TypedDict, total=False):
     # retried until the phase timeout (prod cycle 65ab4b0fdf3e).
     retry_count: int
     max_dev_retries: int
-    deps_installed: bool  # requirements.txt installed once per dev iteration
+    deps_fingerprint: str  # hash of requirements.txt last installed
     blockers: list[dict]
     pr: dict | None
     # TechLead-specific

--- a/tests/test_dev_deps_install_once.py
+++ b/tests/test_dev_deps_install_once.py
@@ -1,18 +1,16 @@
-"""Dependencies install once per dev iteration, not once per retry.
+"""Dependencies reinstall when requirements change, and only then.
 
-Prod repro (cycle 1d816463e34b): ``pip install -r requirements.txt`` hangs
-for its full 120s timeout in the deploy container and always fails. The
-Ralph Loop re-enters ``run_quality_gates`` after every retry, so three
-identical installs ate 360s of the 480s phase budget and the phase timeout
-killed the iteration before ``open_pull_request`` could run — no PR, even
-though the commit had landed.
+Two prod failures shaped this. Reinstalling on every Ralph Loop retry ate
+360s of the 480s phase budget (cycle 1d816463e34b). But a flat
+"already installed" flag was wrong in the other direction: a retry that adds
+a missing dependency needs it installed, and skipping that left the target's
+tests failing on a module the retry had just declared (cycle 8170b32ca48f).
+Keying on the file's content satisfies both.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
-
-from theswarm.agents.dev import run_quality_gates
+from theswarm.agents.dev import _requirements_fingerprint, run_quality_gates
 
 
 class _FakeClaude:
@@ -24,8 +22,8 @@ class _FakeClaude:
         return {"passed": False, "output": "boom", "exit_code": 1}
 
 
-def _write_requirements(tmp_path):
-    (tmp_path / "requirements.txt").write_text("fastapi\n")
+def _workspace(tmp_path, contents="fastapi\n"):
+    (tmp_path / "requirements.txt").write_text(contents)
     return str(tmp_path)
 
 
@@ -33,44 +31,80 @@ def _install_calls(claude: _FakeClaude) -> list[list[str]]:
     return [c for c in claude.commands if "pip" in c]
 
 
-async def test_first_run_installs_dependencies(tmp_path):
+async def test_first_run_installs(tmp_path):
     claude = _FakeClaude()
-    state = {"task": {"number": 1}, "workspace": _write_requirements(tmp_path), "claude": claude}
-
-    result = await run_quality_gates(state)
+    result = await run_quality_gates(
+        {"task": {"number": 1}, "workspace": _workspace(tmp_path), "claude": claude},
+    )
 
     assert len(_install_calls(claude)) == 1
-    assert result["deps_installed"] is True
+    assert result["deps_fingerprint"]
 
 
-async def test_retry_run_skips_reinstall(tmp_path):
-    """The expensive, always-failing install must not repeat on a retry."""
+async def test_retry_with_unchanged_requirements_skips_reinstall(tmp_path):
     claude = _FakeClaude()
-    state = {
-        "task": {"number": 1},
-        "workspace": _write_requirements(tmp_path),
-        "claude": claude,
-        "deps_installed": True,
-    }
+    workspace = _workspace(tmp_path)
+    fingerprint = _requirements_fingerprint(str(tmp_path / "requirements.txt"))
 
-    result = await run_quality_gates(state)
+    result = await run_quality_gates({
+        "task": {"number": 1},
+        "workspace": workspace,
+        "claude": claude,
+        "deps_fingerprint": fingerprint,
+    })
 
     assert _install_calls(claude) == []
-    assert result["deps_installed"] is True
-    # pytest still runs — only the install is skipped
-    assert any("pytest" in c for c in claude.commands)
+    assert any("pytest" in c for c in claude.commands)  # tests still run
+    assert result["deps_fingerprint"] == fingerprint
+
+
+async def test_retry_that_adds_a_dependency_reinstalls(tmp_path):
+    """The regression: a retry declaring httpx must actually install it."""
+    claude = _FakeClaude()
+    workspace = _workspace(tmp_path, "fastapi\n")
+    stale = _requirements_fingerprint(str(tmp_path / "requirements.txt"))
+
+    # The Ralph Loop retry adds the missing dependency
+    (tmp_path / "requirements.txt").write_text("fastapi\nhttpx\n")
+
+    result = await run_quality_gates({
+        "task": {"number": 1},
+        "workspace": workspace,
+        "claude": claude,
+        "deps_fingerprint": stale,
+    })
+
+    assert len(_install_calls(claude)) == 1
+    assert result["deps_fingerprint"] != stale
 
 
 async def test_no_requirements_file_skips_install(tmp_path):
     claude = _FakeClaude()
-    state = {"task": {"number": 1}, "workspace": str(tmp_path), "claude": claude}
-
-    await run_quality_gates(state)
+    result = await run_quality_gates(
+        {"task": {"number": 1}, "workspace": str(tmp_path), "claude": claude},
+    )
 
     assert _install_calls(claude) == []
+    assert result["deps_fingerprint"] == ""
 
 
-async def test_deps_installed_is_declared_in_state():
+def test_fingerprint_tracks_content(tmp_path):
+    req = tmp_path / "requirements.txt"
+    req.write_text("fastapi\n")
+    first = _requirements_fingerprint(str(req))
+
+    req.write_text("fastapi\n")
+    assert _requirements_fingerprint(str(req)) == first
+
+    req.write_text("fastapi\nhttpx\n")
+    assert _requirements_fingerprint(str(req)) != first
+
+
+def test_fingerprint_of_missing_file_is_empty(tmp_path):
+    assert _requirements_fingerprint(str(tmp_path / "nope.txt")) == ""
+
+
+def test_deps_fingerprint_is_declared_in_state():
     from theswarm.config import AgentState
 
-    assert "deps_installed" in AgentState.__annotations__
+    assert "deps_fingerprint" in AgentState.__annotations__

--- a/tests/test_qa_readiness_diagnostics.py
+++ b/tests/test_qa_readiness_diagnostics.py
@@ -1,0 +1,88 @@
+"""A target app that fails to boot must say why.
+
+Prod repro (cycle 8170b32ca48f): the target's uvicorn died on import because
+its requirements.txt omitted a module its conftest imported. Its stdout was
+piped but never read, so the logs showed only a bare
+``ERR_CONNECTION_REFUSED`` with no cause anywhere — the interesting error was
+captured and thrown away.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from theswarm.agents.qa import _log_readiness_failure
+from theswarm.infrastructure.resilience import ReadinessTimeout
+
+
+class _ExitedProc:
+    """A server that crashed on import and left its traceback on stdout."""
+
+    returncode = 1
+
+    async def communicate(self):
+        return (b"ModuleNotFoundError: No module named 'httpx'\n", b"")
+
+
+class _RunningProc:
+    """Alive but not serving — reading it would block forever."""
+
+    returncode = None
+    communicate_called = False
+
+    async def communicate(self):
+        type(self).communicate_called = True
+        await asyncio.sleep(60)
+
+
+class _SilentProc:
+    returncode = 2
+
+    async def communicate(self):
+        return (b"", b"")
+
+
+async def test_crashed_server_output_reaches_the_log(caplog):
+    with caplog.at_level(logging.WARNING):
+        await _log_readiness_failure(
+            "QA screenshots", _ExitedProc(), ReadinessTimeout("not ready after 30s"),
+        )
+
+    message = caplog.text
+    assert "No module named 'httpx'" in message
+    assert "rc=1" in message
+
+
+async def test_running_server_is_not_read(caplog):
+    """communicate() on a live process would hang the phase."""
+    with caplog.at_level(logging.WARNING):
+        await _log_readiness_failure(
+            "QA E2E", _RunningProc(), ReadinessTimeout("not ready after 30s"),
+        )
+
+    assert _RunningProc.communicate_called is False
+    assert "still running but not serving" in caplog.text
+
+
+async def test_silent_crash_is_reported_without_output(caplog):
+    with caplog.at_level(logging.WARNING):
+        await _log_readiness_failure(
+            "QA video", _SilentProc(), ReadinessTimeout("not ready after 30s"),
+        )
+
+    assert "rc=2" in caplog.text
+    assert "no output captured" in caplog.text
+
+
+def test_every_readiness_handler_uses_the_diagnostic():
+    """All three server starts must report, not swallow, a boot failure."""
+    import inspect
+
+    from theswarm.agents import qa
+
+    source = inspect.getsource(qa)
+    assert source.count("_log_readiness_failure(") == 4  # 1 def + 3 call sites
+    assert "running tests anyway" not in source
+    assert "capturing anyway" not in source
+    assert "recording anyway" not in source


### PR DESCRIPTION
Follow-up from validating #17 on a real cycle (8170b32ca48f). Both fixes from that PR landed — the log shows `/usr/local/bin/python3 -m pip install`, and Playwright now reaches the network layer (`ERR_CONNECTION_REFUSED`) instead of raising `ImportError`. Two things behind them still blocked the run.

### 1. A regression I introduced in #14

The `deps_installed` boolean from #14 was too blunt. Skipping the reinstall on every Ralph Loop retry saved the phase budget, but a retry that *adds* a missing dependency needs it installed. So the cycle looped like this:

```
Tests FAILED: ModuleNotFoundError: No module named 'httpx'
Committed: fix: address test failures for #173 (retry 1)
Tests FAILED: ModuleNotFoundError: No module named 'httpx'
```

The retry declared the dependency and the install was skipped, so it never arrived. Keying the skip on a **hash of requirements.txt** satisfies both constraints: unchanged requirements still skip the expensive install, a changed file reinstalls.

(The root trigger is in the target repo — `concert-tour-app`'s `requirements.txt` omits `httpx` while its `conftest.py` imports it. But TheSwarm's retry loop is supposed to be able to fix exactly that, and this is what stopped it.)

### 2. A target that dies on import said nothing

`uvicorn`'s stdout is piped and never read, so a crash-on-import left only a bare connection-refused in the logs with the traceback discarded — the interesting error was captured and thrown away. Readiness failures now read the process output back when it has exited, and report that it is alive when it has not (reading a live process would block the phase).

Also aligned QA's unit-test run on the shared interpreter — the last bare `python` left in the agents.

## Test plan

- [x] Unchanged requirements skip the reinstall; tests still run
- [x] A retry adding a dependency triggers a reinstall (the regression above)
- [x] Missing requirements.txt installs nothing
- [x] Fingerprint tracks content, empty for a missing file
- [x] Crashed server's output reaches the log with its exit code
- [x] A live process is never read (would hang the phase)
- [x] All three readiness handlers use the diagnostic — no "anyway" swallowing left
- [x] Full suite: 2222 passing
- [ ] Post-deploy: run a cycle and confirm the retry loop can now install what it declares

Rebased on `main` (`b316dce`).