### PR TITLE
feat(cycle): pin a cycle to one GitHub issue — Play on a GHI

### DIFF
--- a/src/theswarm/agents/dev.py
+++ b/src/theswarm/agents/dev.py
@@ -92,12 +92,65 @@ Focus on correctness and simplicity. Ship working code.
 # ── Node functions ──────────────────────────────────────────────────────
 
 
+def _label_names(issue: dict) -> set[str]:
+    return {
+        label if isinstance(label, str) else label.get("name", "")
+        for label in issue.get("labels", [])
+    }
+
+
+async def _mark_in_progress(github, task: dict) -> None:
+    await asyncio.gather(
+        github.add_labels(task["number"], ["status:in-progress"]),
+        github.remove_label(task["number"], "status:ready"),
+    )
+
+
+async def _pick_targeted(github, target_issue: int) -> dict | None:
+    """Issue-driven flow (P1): resolve the pinned issue to a workable task.
+
+    Order: the target itself when it is directly implementable (open,
+    ``role:dev``, not already in review), otherwise its ``Parent: #N``
+    children created by the TechLead breakdown. Never falls back to
+    unrelated backlog — a targeted cycle implements this issue or nothing.
+    """
+    target = await github.get_issue(target_issue)
+    if target is None or target.get("state") == "closed":
+        log.info("Target issue #%s not found or closed", target_issue)
+        return None
+
+    labels = _label_names(target)
+    if "role:dev" in labels and "status:review" not in labels:
+        # Pressed Play on a directly implementable task: take it whatever
+        # its status label says (backlog, ready, or orphaned in-progress).
+        return target
+
+    ready = await github.get_issues(labels=["role:dev", "status:ready"])
+    parent_marker = f"Parent: #{target_issue}"
+    for child in ready:
+        if parent_marker in (child.get("body") or ""):
+            return child
+
+    log.info("Target #%s has no workable task (state=%s, labels=%s)",
+             target_issue, target.get("state"), sorted(labels))
+    return None
+
+
 async def pick_task(state: AgentState) -> dict:
-    """Pick the next role:dev + status:ready task from GitHub."""
+    """Pick the next task: the targeted issue if one is pinned, else backlog."""
     github = state.get("github")
     if github is None:
         return stub_result(Role.DEV, "pick_task",
                            "pick first issue with labels role:dev + status:ready")
+
+    target_issue = state.get("target_issue")
+    if target_issue:
+        task = await _pick_targeted(github, target_issue)
+        if task is None:
+            return {"task": None, "tokens_used": 0}
+        log.info("Picked targeted task: #%d %s", task["number"], task["title"])
+        await _mark_in_progress(github, task)
+        return {"task": task, "tokens_used": 0}
 
     # Look for tasks labeled for dev work
     for labels in [["role:dev", "status:ready"], ["status:ready"]]:
@@ -105,11 +158,7 @@ async def pick_task(state: AgentState) -> dict:
         if issues:
             task = issues[0]
             log.info("Picked task: #%d %s", task["number"], task["title"])
-            # Mark as in-progress
-            await asyncio.gather(
-                github.add_labels(task["number"], ["status:in-progress"]),
-                github.remove_label(task["number"], "status:ready"),
-            )
+            await _mark_in_progress(github, task)
             return {"task": task, "tokens_used": 0}
 
     log.warning("No ready tasks found")

--- a/src/theswarm/agents/techlead.py
+++ b/src/theswarm/agents/techlead.py
@@ -129,8 +129,19 @@ async def breakdown_stories(state: AgentState) -> dict:
         return stub_result(Role.TECHLEAD, "breakdown_stories",
                            "split US into 2-4 technical tasks, create sub-issues")
 
-    # Fetch issues that PO marked as ready but haven't been broken down yet
-    ready_issues = await github.get_issues(labels=["status:ready"])
+    # Issue-driven flow (P1): a targeted cycle breaks down ONLY the target
+    # issue, whatever its current status label — the user pressed Play on
+    # it, so it must not wait for the PO to move it to ready.
+    target_issue = state.get("target_issue")
+    if target_issue:
+        target = await github.get_issue(target_issue)
+        if target is None or target.get("state") == "closed":
+            log.info("TechLead: target issue #%s not found or closed — nothing to break down", target_issue)
+            return {"result": f"Target #{target_issue} not available", "tokens_used": 0}
+        ready_issues = [target]
+    else:
+        # Fetch issues that PO marked as ready but haven't been broken down yet
+        ready_issues = await github.get_issues(labels=["status:ready"])
     # Filter out issues that already have sub-tasks (role:dev label)
     ready_issues = [i for i in ready_issues if not any(
         (l if isinstance(l, str) else l.get("name", "")) == "role:dev"

--- a/src/theswarm/api.py
+++ b/src/theswarm/api.py
@@ -38,6 +38,7 @@ class CycleRequest(BaseModel):
     repo: str
     description: str = ""
     callback_url: str = ""
+    issue_number: int | None = None
 
 
 class CycleRecord(BaseModel):
@@ -218,6 +219,7 @@ async def run_api_cycle(
     cycle_repo: object | None = None,
     project_id: str = "",
     checkpoint_repo: object | None = None,
+    issue_number: int | None = None,
     resume_from: str | None = None,
     role_assignment_service: object | None = None,
 ) -> None:
@@ -291,7 +293,10 @@ async def run_api_cycle(
             dash.push_event(role, message)
 
     try:
-        cycle_config = CycleConfig(github_repo=repo, project_id=project_id or repo)
+        cycle_config = CycleConfig(
+            github_repo=repo, project_id=project_id or repo,
+            target_issue=issue_number,
+        )
 
         # Populate codenames for persona rendering. Cheap DB read; skipped
         # cleanly if the service is unavailable.

--- a/src/theswarm/config.py
+++ b/src/theswarm/config.py
@@ -49,6 +49,7 @@ class AgentState(TypedDict, total=False):
     # retried until the phase timeout (prod cycle 65ab4b0fdf3e).
     retry_count: int
     max_dev_retries: int
+    target_issue: int | None  # issue-driven flow: pin the cycle to one GH issue
     deps_fingerprint: str  # hash of requirements.txt last installed
     blockers: list[dict]
     pr: dict | None
@@ -103,6 +104,11 @@ class CycleConfig:
 
     # Ralph Loop: max retries when quality gates fail
     max_dev_retries: int = 2
+
+    # Issue-driven flow (P1): when set, the cycle implements THIS GitHub
+    # issue and nothing else — breakdown scopes to it, the dev loop pins it
+    # then its `Parent: #N` children, and never drains unrelated backlog.
+    target_issue: int | None = None
 
     # Watchdog: idle threshold in seconds (> Claude's 600s timeout)
     watchdog_idle_threshold: float = 720.0

--- a/src/theswarm/cycle.py
+++ b/src/theswarm/cycle.py
@@ -148,6 +148,7 @@ def _build_base_state(config: CycleConfig) -> dict:
         # Honour the project's configured retry budget instead of the
         # dev-graph default.
         "max_dev_retries": config.max_dev_retries,
+        "target_issue": config.target_issue,
     }
 
     if config.is_real_mode:

--- a/src/theswarm/presentation/web/routes/api.py
+++ b/src/theswarm/presentation/web/routes/api.py
@@ -324,6 +324,7 @@ async def start_cycle(request: Request) -> JSONResponse:
             project_repo=project_repo, cycle_repo=cycle_repo,
             project_id=project_id,
             role_assignment_service=role_assignment_service,
+            issue_number=req.issue_number,
         )
     )
     tracker.set_task(record.id, task)

--- a/src/theswarm/tools/github.py
+++ b/src/theswarm/tools/github.py
@@ -7,6 +7,7 @@ async event loop.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from dataclasses import dataclass, field
 from functools import partial
@@ -14,6 +15,8 @@ from typing import Any
 
 from github import Github, GithubException, RateLimitExceededException
 from github.Issue import Issue
+
+log = logging.getLogger(__name__)
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
@@ -60,6 +63,17 @@ class GitHubClient:
             lambda: list(self._repo.get_issues(**kwargs))
         )
         return [_issue_to_dict(i) for i in issues if not i.pull_request]
+
+    async def get_issue(self, number: int) -> dict | None:
+        """Return one issue as a dict, or None if it does not exist."""
+        try:
+            issue: Issue = await self._run(self._repo.get_issue, number)
+        except Exception:
+            log.warning("get_issue(#%d) failed", number, exc_info=True)
+            return None
+        if issue.pull_request:
+            return None
+        return _issue_to_dict(issue)
 
     async def create_issue(
         self,

--- a/tests/test_target_issue_flow.py
+++ b/tests/test_target_issue_flow.py
@@ -1,0 +1,214 @@
+"""Issue-driven flow P1 (theswarm#23): a cycle pinned to one GitHub issue.
+
+`POST /api/cycle {"repo": …, "issue_number": N}` must implement issue #N and
+nothing else: the TechLead breakdown scopes to it, the dev loop picks it (or
+its `Parent: #N` children once broken down), and a targeted cycle never
+drains unrelated backlog.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from theswarm.agents.dev import pick_task
+from theswarm.agents.techlead import breakdown_stories
+from theswarm.api import CycleRequest, CycleStatus, get_cycle_tracker, run_api_cycle
+from theswarm.config import AgentState, CycleConfig
+from theswarm.cycle import _build_base_state
+
+
+class _FakeGitHub:
+    """In-memory issue store mimicking GitHubClient's dict shape."""
+
+    def __init__(self, issues: list[dict]) -> None:
+        self.issues = {i["number"]: i for i in issues}
+        self.created: list[dict] = []
+        self.label_ops: list[tuple[str, int, object]] = []
+
+    async def get_issue(self, number: int) -> dict | None:
+        return self.issues.get(number)
+
+    async def get_issues(self, labels=None, state="open") -> list[dict]:
+        out = []
+        for issue in self.issues.values():
+            if issue.get("state", "open") != state:
+                continue
+            if labels and not set(labels) <= set(issue.get("labels", [])):
+                continue
+            out.append(issue)
+        return sorted(out, key=lambda i: i["number"])
+
+    async def create_issue(self, title, body="", labels=None, assignees=None) -> dict:
+        number = max(self.issues, default=0) + 1
+        issue = {"number": number, "title": title, "body": body,
+                 "labels": list(labels or []), "state": "open"}
+        self.issues[number] = issue
+        self.created.append(issue)
+        return issue
+
+    async def add_labels(self, number: int, labels: list[str]) -> None:
+        self.label_ops.append(("add", number, tuple(labels)))
+        self.issues[number]["labels"] = list(
+            set(self.issues[number]["labels"]) | set(labels)
+        )
+
+    async def remove_label(self, number: int, label: str) -> None:
+        self.label_ops.append(("remove", number, label))
+        if label in self.issues[number]["labels"]:
+            self.issues[number]["labels"].remove(label)
+
+
+def _issue(number, title="t", labels=(), body="", state="open"):
+    return {"number": number, "title": title, "labels": list(labels),
+            "body": body, "state": state}
+
+
+# ── Transport: request → config → agent state ─────────────────────────
+
+
+def test_cycle_request_accepts_issue_number():
+    assert CycleRequest(repo="o/r", issue_number=42).issue_number == 42
+    assert CycleRequest(repo="o/r").issue_number is None
+
+
+def test_agent_state_declares_target_issue():
+    assert "target_issue" in AgentState.__annotations__
+
+
+def test_base_state_carries_target_issue():
+    config = CycleConfig(github_repo="", target_issue=7)
+    assert _build_base_state(config)["target_issue"] == 7
+
+
+async def test_run_api_cycle_pins_config_to_the_issue():
+    captured: dict = {}
+
+    async def fake_cycle(config, **kwargs):
+        captured["target"] = config.target_issue
+        return {"date": "2026-08-30", "cost_usd": 0.0, "prs": [], "reviews": []}
+
+    tracker = get_cycle_tracker()
+    record = tracker.create(CycleRequest(repo="owner/some-repo", issue_number=146))
+
+    with patch("theswarm.cycle.run_daily_cycle", side_effect=fake_cycle):
+        await run_api_cycle(
+            cycle_id=record.id, repo="owner/some-repo", description="",
+            callback_url="", allowed_repos=[], issue_number=146,
+        )
+
+    assert captured["target"] == 146
+    assert tracker.get(record.id).status == CycleStatus.COMPLETED
+
+
+# ── Dev: targeted pick ─────────────────────────────────────────────────
+
+
+async def test_targeted_pick_takes_the_issue_whatever_its_status():
+    """Play on a backlog task must not wait for the PO to mark it ready."""
+    github = _FakeGitHub([
+        _issue(5, "unrelated ready", ["role:dev", "status:ready"]),
+        _issue(9, "the target", ["role:dev", "status:backlog"]),
+    ])
+
+    result = await pick_task({"github": github, "target_issue": 9})
+
+    assert result["task"]["number"] == 9
+    assert "status:in-progress" in github.issues[9]["labels"]
+
+
+async def test_targeted_pick_prefers_children_once_broken_down():
+    github = _FakeGitHub([
+        _issue(9, "story", ["status:in-progress"]),  # broken down, no role:dev
+        _issue(5, "unrelated ready", ["role:dev", "status:ready"]),
+        _issue(12, "child task", ["role:dev", "status:ready"], body="Do it\n\nParent: #9"),
+    ])
+
+    result = await pick_task({"github": github, "target_issue": 9})
+
+    assert result["task"]["number"] == 12
+
+
+async def test_targeted_pick_never_drains_unrelated_backlog():
+    """Target done (in review), no children left → None, not issue #5."""
+    github = _FakeGitHub([
+        _issue(9, "the target", ["role:dev", "status:review"]),
+        _issue(5, "unrelated ready", ["role:dev", "status:ready"]),
+    ])
+
+    result = await pick_task({"github": github, "target_issue": 9})
+
+    assert result["task"] is None
+    assert github.issues[5]["labels"] == ["role:dev", "status:ready"]  # untouched
+
+
+async def test_targeted_pick_handles_missing_or_closed_issue():
+    github = _FakeGitHub([_issue(9, "done", ["role:dev"], state="closed")])
+
+    assert (await pick_task({"github": github, "target_issue": 9}))["task"] is None
+    assert (await pick_task({"github": github, "target_issue": 404}))["task"] is None
+
+
+async def test_untargeted_pick_keeps_backlog_behaviour():
+    github = _FakeGitHub([_issue(5, "ready task", ["role:dev", "status:ready"])])
+
+    result = await pick_task({"github": github})
+
+    assert result["task"]["number"] == 5
+
+
+# ── TechLead: scoped breakdown ─────────────────────────────────────────
+
+
+class _FakeClaude:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.calls = 0
+
+    async def run(self, prompt, **kwargs):
+        self.calls += 1
+
+        class R:
+            text = self.text
+            total_tokens = 10
+            cost_usd = 0.0
+        return R()
+
+
+async def test_breakdown_scopes_to_the_target_story():
+    github = _FakeGitHub([
+        _issue(9, "target story", ["status:backlog"], body="Build the dashboard"),
+        _issue(5, "unrelated ready story", ["status:ready"], body="Other work"),
+    ])
+    claude = _FakeClaude('[{"title": "T1", "body": "B1"}]')
+
+    await breakdown_stories({"github": github, "claude": claude, "target_issue": 9})
+
+    assert claude.calls == 1  # only the target, not the unrelated ready story
+    assert len(github.created) == 1
+    assert "Parent: #9" in github.created[0]["body"]
+    # Unrelated ready story untouched
+    assert github.issues[5]["labels"] == ["status:ready"]
+
+
+async def test_breakdown_skips_target_that_is_already_a_task():
+    github = _FakeGitHub([_issue(9, "small task", ["role:dev", "status:ready"])])
+    claude = _FakeClaude("[]")
+
+    result = await breakdown_stories(
+        {"github": github, "claude": claude, "target_issue": 9},
+    )
+
+    assert claude.calls == 0
+    assert "No issues to break down" in result["result"]
+
+
+async def test_breakdown_reports_missing_target():
+    github = _FakeGitHub([])
+    claude = _FakeClaude("[]")
+
+    result = await breakdown_stories(
+        {"github": github, "claude": claude, "target_issue": 404},
+    )
+
+    assert claude.calls == 0
+    assert "404" in result["result"]


### PR DESCRIPTION
Implements #23 — first brick of the issue-driven flow (docs/plans/2026-08-issue-driven-flow.md, P1).

`POST /api/cycle {"repo": …, "issue_number": N}` now runs a cycle that implements **issue #N and nothing else**:

- **Transport**: `CycleRequest.issue_number` → `run_api_cycle(issue_number=…)` → `CycleConfig.target_issue` → agent state (`target_issue` declared in `AgentState`, per the schema guard).
- **TechLead breakdown** scopes to the target whatever its status label — the user pressed Play, it must not wait for the PO to move it to ready. A target that already carries `role:dev` is a task, not a story: nothing to break down.
- **Dev pick** resolves the pin in order: the target itself when directly implementable (open, `role:dev`, not `status:review`) — forced `→ in-progress` from any starting label — else its `Parent: #N` children created by the breakdown, else `None`. **A targeted cycle never drains unrelated backlog.**
- `GitHubClient.get_issue(number)` added (single fetch, PRs filtered out, module logger added on the way).

Untargeted cycles keep the exact existing behaviour.

## Test plan
- [x] Request/config/state transport (`issue_number` → `target_issue`, tracker completes)
- [x] Targeted pick: takes a backlog task directly; prefers `Parent: #N` children once broken down; returns `None` instead of touching unrelated ready issues; handles closed/missing targets
- [x] Scoped breakdown: only the target story is broken down (1 Claude call), children reference `Parent: #N`; `role:dev` targets skipped; missing target reported
- [x] Untargeted behaviour unchanged
- [x] Full suite: 2246 passing
- [ ] Post-deploy: real cycle with `issue_number` on concert-tour-app — verify only that issue moves

Closes #23