### PR TITLE
ops(auth): durable headless Claude CLI auth via CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/.github/actions/write-env/action.yml
+++ b/.github/actions/write-env/action.yml
@@ -21,6 +21,9 @@ inputs:
     required: true
   swarm_vault_master_key:
     required: true
+  claude_code_oauth_token:
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -36,6 +39,7 @@ runs:
         SEQ_URL: ${{ inputs.seq_url }}
         SEQ_API_KEY: ${{ inputs.seq_api_key }}
         SWARM_VAULT_MASTER_KEY: ${{ inputs.swarm_vault_master_key }}
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
       run: |
         {
           echo "MATTERMOST_BOT_TOKEN=$MATTERMOST_BOT_TOKEN"
@@ -48,4 +52,5 @@ runs:
           echo "SEQ_URL=$SEQ_URL"
           echo "SEQ_API_KEY=$SEQ_API_KEY"
           echo "SWARM_VAULT_MASTER_KEY=$SWARM_VAULT_MASTER_KEY"
+          echo "CLAUDE_CODE_OAUTH_TOKEN=$CLAUDE_CODE_OAUTH_TOKEN"
         } > .env

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,6 +89,7 @@ jobs:
           seq_url: ${{ secrets.SEQ_URL }}
           seq_api_key: ${{ secrets.SEQ_API_KEY }}
           swarm_vault_master_key: ${{ secrets.SWARM_VAULT_MASTER_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - name: Deploy
         run: |
           export TS_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -155,6 +156,7 @@ jobs:
           seq_url: ${{ secrets.SEQ_URL }}
           seq_api_key: ${{ secrets.SEQ_API_KEY }}
           swarm_vault_master_key: ${{ secrets.SWARM_VAULT_MASTER_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - name: Redeploy (latest)
         run: |
           export TS_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,12 @@ Full details: `docs/ARCHITECTURE-V2.md`, `docs/ROLES-OVERVIEW.md`.
 
 ## Environment
 
-Secrets in `.env` (never committed). Key vars: `ANTHROPIC_API_KEY` (only a real
-`sk-ant-api` key enables the API fallback; an `sk-ant-oat` OAuth token is
-CLI-only and is deliberately ignored by the fallback), `GITHUB_TOKEN` (push auth,
+Secrets in `.env` (never committed). Key vars: `CLAUDE_CODE_OAUTH_TOKEN`
+(headless auth for the Claude CLI, minted with `claude setup-token`; the
+browser-session credentials mounted from the host expire when their refresh
+token dies), `ANTHROPIC_API_KEY` (only a real `sk-ant-api` key enables the API
+fallback; an `sk-ant-oat` OAuth token is CLI-only and is deliberately ignored
+by the fallback), `GITHUB_TOKEN` (push auth,
 injected per git command — never written to `.git/config`), `SWARM_GITHUB_REPO`,
 `MATTERMOST_BOT_TOKEN`, `BASE_PATH` (reverse-proxy prefix, templates use
 `{{ base }}`), `SEQ_URL`/`SEQ_API_KEY` (log aggregation).


### PR DESCRIPTION
The container's Claude session died mid-cycle (`e2002845e607`): the CLI tried to refresh the browser-session OAuth mounted from the host, the refresh token was expired, and it persisted an invalidated credentials file (`Not logged in · Please run /login`, `expiresAt: 0`). A browser session is the wrong credential for a headless box — it dies whenever the refresh token does.

This wires `CLAUDE_CODE_OAUTH_TOKEN` (minted with `claude setup-token`) through the deploy path: optional `write-env` input → both `cd.yml` jobs pass the `CLAUDE_CODE_OAUTH_TOKEN` secret → compose `env_file` → the CLI subprocess env (which already forwards everything except `ANTHROPIC_API_KEY`). Documented in AGENTS.md.

**No behaviour change until the operator sets the secret**:
```
claude setup-token          # on a machine with a browser
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo jrechet/theswarm
```
Next deploy after that authenticates the CLI durably.

P1's guards did their job around the outage: the targeted cycle failed in 3s with a clear error, requeued #173, and left the 17-issue backlog untouched.