### PR TITLE
fix(dev): unblock the targeted loop — idempotent branch, guarded PR, no re-pick

### DIFF
--- a/src/theswarm/agents/dev.py
+++ b/src/theswarm/agents/dev.py
@@ -359,6 +359,11 @@ def _should_skip(state: AgentState) -> str:
     return "implement"
 
 
+async def _noop(state: AgentState) -> dict:
+    """Routing-only node: carries the graph to the open-PR decision."""
+    return {}
+
+
 def _should_open_pr(state: AgentState) -> str:
     """Skip PR if no branch was created or no changes were committed."""
     if state.get("branch") is None or not state.get("diff_stat"):
@@ -445,13 +450,23 @@ def build_dev_graph() -> StateGraph:
         "implement": "implement",
         "end": END,
     })
+    graph.add_node("check_pr", _noop)
+
     graph.add_edge("implement", "quality_gates")
-    # Ralph Loop: retry if tests fail, otherwise proceed to PR
+    # Ralph Loop: retry if tests fail, otherwise consider opening a PR
     graph.add_conditional_edges("quality_gates", _should_retry, {
         "retry": "retry_implement",
-        "check_pr": "open_pr",
+        "check_pr": "check_pr",
     })
     graph.add_edge("retry_implement", "quality_gates")  # re-run tests after retry
+    # _should_open_pr existed but was never wired: the loop ran straight into
+    # open_pr, so a task that committed nothing still tried to open one and
+    # GitHub answered 422 'No commits between main and …' (prod cycle
+    # 89c42c25875a, a verification task with nothing to change).
+    graph.add_conditional_edges("check_pr", _should_open_pr, {
+        "open_pr": "open_pr",
+        "end": END,
+    })
     graph.add_edge("open_pr", END)
 
     return graph.compile()

--- a/src/theswarm/cycle.py
+++ b/src/theswarm/cycle.py
@@ -317,6 +317,7 @@ async def run_daily_cycle(
             )
 
         # --- DEVELOPMENT: Dev implements → TechLead reviews → repeat ---
+        attempted_without_pr: set[int] = set()
         _dev_loop_ran = not _skip("dev_loop")
         if _dev_loop_ran:
             _enter("dev_loop")
@@ -379,7 +380,21 @@ async def run_daily_cycle(
                 if task is None:
                     await _progress("Dev", "No more ready tasks — ending dev loop")
                     break
-                await _progress("Dev", f"No PR produced for task #{task['number']}")
+                # A task that yields no PR twice yields none at all: a
+                # verification story with nothing to change, or work the
+                # model cannot complete. Without this the loop re-picks it
+                # every iteration — harmless before targeting (each iteration
+                # took a different issue), a guaranteed five-times-nothing
+                # once the cycle is pinned to one issue.
+                number = task["number"]
+                if number in attempted_without_pr:
+                    await _progress(
+                        "Dev",
+                        f"Task #{number} produced no changes twice — ending dev loop",
+                    )
+                    break
+                attempted_without_pr.add(number)
+                await _progress("Dev", f"No PR produced for task #{number}")
 
             # TechLead reviews and merges
             await _progress("TechLead", "Reviewing open PRs…")

--- a/src/theswarm/tools/git.py
+++ b/src/theswarm/tools/git.py
@@ -112,10 +112,18 @@ async def clone_repo(repo_url: str, dest: str) -> str:
 
 
 async def create_branch(workdir: str, branch_name: str, base: str = "main") -> None:
-    """Create and checkout a new branch from base."""
+    """Create (or reset) a branch at the tip of base and check it out.
+
+    ``-B`` rather than ``-b``: the workspace is reused across dev iterations,
+    so a retried task derives the same branch name and ``-b`` fails with
+    rc=128 'a branch named X already exists'. Pinning a cycle to one issue
+    made that permanent — every retry rebuilt the same name and burned the
+    iteration (prod cycle 89c42c25875a). Each attempt wants a clean branch
+    off base anyway, which is exactly what resetting gives.
+    """
     await _run_git("checkout", base, cwd=workdir)
     await _run_git(*_auth_args(), "pull", "--ff-only", cwd=workdir, check=False)
-    await _run_git("checkout", "-b", branch_name, cwd=workdir)
+    await _run_git("checkout", "-B", branch_name, cwd=workdir)
     log.info("Created branch %s from %s", branch_name, base)
 
 

--- a/tests/test_dev_loop_no_progress_guards.py
+++ b/tests/test_dev_loop_no_progress_guards.py
@@ -1,0 +1,125 @@
+"""Guards exposed by pinning a cycle to one issue (prod cycle 89c42c25875a).
+
+Targeting made three latent bugs permanent, because every iteration now
+derives the same branch name and re-picks the same task instead of drifting
+to a different issue:
+
+1. `create_branch` used `checkout -b`, which fails rc=128 once the branch
+   exists — iterations 2..5 all died there.
+2. `_should_open_pr` existed but was never wired into the graph, so a task
+   that committed nothing still tried to open a PR: GitHub 422 "No commits
+   between main and …".
+3. The dev loop re-picked a task that produced nothing, five times over.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from theswarm import cycle as cycle_mod
+from theswarm.agents.dev import _should_open_pr, build_dev_graph
+from theswarm.config import CycleConfig
+from theswarm.cycle import run_daily_cycle
+from theswarm.tools.git import create_branch
+
+
+@pytest.fixture()
+def mock_subprocess(mocker):
+    proc = AsyncMock()
+    proc.returncode = 0
+    proc.communicate = AsyncMock(return_value=(b"", b""))
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+    return proc
+
+
+# ── 1. Branch creation is idempotent ───────────────────────────────────
+
+
+async def test_create_branch_resets_instead_of_failing(mock_subprocess):
+    await create_branch("/tmp/repo", "feat/issue-173-x")
+
+    branch_call = [
+        c.args for c in asyncio.create_subprocess_exec.call_args_list
+        if "checkout" in c.args
+    ][-1]
+    # -B creates or resets; -b fails rc=128 when the branch already exists
+    assert "-B" in branch_call
+    assert "-b" not in branch_call
+    assert branch_call[-1] == "feat/issue-173-x"
+
+
+# ── 2. No commits → no PR attempt ──────────────────────────────────────
+
+
+def test_should_open_pr_requires_a_branch_and_a_diff():
+    assert _should_open_pr({"branch": "feat/x", "diff_stat": " f.py | 2 +-"}) == "open_pr"
+    assert _should_open_pr({"branch": "feat/x", "diff_stat": ""}) == "end"
+    assert _should_open_pr({"branch": None, "diff_stat": "x"}) == "end"
+    assert _should_open_pr({}) == "end"
+
+
+def test_graph_routes_through_the_open_pr_guard():
+    """The guard must sit between the Ralph Loop and open_pr, not be dead code."""
+    drawn = build_dev_graph().get_graph()
+    edges = {(e.source, e.target) for e in drawn.edges}
+
+    assert "check_pr" in set(drawn.nodes), "routing node missing — open_pr runs unguarded"
+    assert ("quality_gates", "open_pr") not in edges
+    assert ("check_pr", "open_pr") in edges
+
+
+# ── 3. The dev loop stops re-picking a task that yields nothing ─────────
+
+
+def _graph_returning(states: list[dict]):
+    """Dev graph stub yielding one state per iteration."""
+    calls = {"n": 0}
+
+    class _Stub:
+        async def ainvoke(self, _state):
+            index = min(calls["n"], len(states) - 1)
+            calls["n"] += 1
+            return states[index]
+
+    return lambda: _Stub(), calls
+
+
+async def test_loop_stops_after_the_same_task_yields_nothing_twice():
+    """Pinned cycles would otherwise burn all five iterations on one issue."""
+    factory, calls = _graph_returning([{"task": {"number": 173}}])  # never a PR
+
+    with patch.object(cycle_mod, "build_dev_graph", factory):
+        await run_daily_cycle(CycleConfig(github_repo=""))
+
+    assert calls["n"] == 2, "expected one retry then a stop, not five iterations"
+
+
+async def test_loop_keeps_going_while_tasks_differ():
+    """Distinct tasks producing no PR are not a stall — keep draining."""
+    factory, calls = _graph_returning([
+        {"task": {"number": 1}},
+        {"task": {"number": 2}},
+        {"task": {"number": 3}},
+        {"task": None},  # backlog exhausted
+    ])
+
+    with patch.object(cycle_mod, "build_dev_graph", factory):
+        await run_daily_cycle(CycleConfig(github_repo=""))
+
+    assert calls["n"] == 4
+
+
+async def test_loop_is_unaffected_when_prs_are_produced():
+    factory, calls = _graph_returning([
+        {"task": {"number": 1}, "pr": {"number": 10, "url": "u"}},
+        {"task": None},
+    ])
+
+    with patch.object(cycle_mod, "build_dev_graph", factory):
+        result = await run_daily_cycle(CycleConfig(github_repo=""))
+
+    assert calls["n"] == 2
+    assert [p["number"] for p in result["prs"]] == [10]

--- a/tests/test_tools_git.py
+++ b/tests/test_tools_git.py
@@ -87,7 +87,9 @@ async def test_create_branch(mock_subprocess):
     assert calls[0].args[1] == "checkout"
     assert calls[0].args[2] == "main"
     assert calls[2].args[1] == "checkout"
-    assert calls[2].args[2] == "-b"
+    # -B, not -b: the workspace is reused across dev iterations, so a retried
+    # task derives the same branch name and -b would fail rc=128.
+    assert calls[2].args[2] == "-B"
     assert calls[2].args[3] == "feat/new"
 
 


### PR DESCRIPTION
Follow-up to #23, from its first real run (prod cycle `89c42c25875a` targeting concert-tour-app#173).

**The targeting itself worked**: `Picked targeted task: #173` on every iteration, never drifting to another issue, backlog untouched (17 ready before and after). But it exposed three latent bugs that backlog drainage had been hiding — because each iteration now derives the *same* branch name and re-picks the *same* task instead of moving on.

| | Bug | Symptom in the log |
|---|---|---|
| 1 | `create_branch` used `checkout -b` | `rc=128: a branch named 'feat/issue-173-…' already exists` — iterations 2..5 all died there |
| 2 | `_should_open_pr` was dead code, never wired into the graph | `422 No commits between main and feat/issue-173-…` after "Extracted 0 files" |
| 3 | The loop re-picked a task that produced nothing | 5 iterations on the same issue, ~$0.26 each |

Fixes: `-B` (create **or reset** — each attempt wants a clean branch off base anyway); a routing node between the Ralph Loop and `open_pr` so the existing guard actually runs; and the loop stops after the same task yields no PR twice.

Worth noting #173 was a *verification* task — "Verify LICENSE file follows standard conventions" — where the model correctly concluded there was nothing to change. That legitimate outcome is what surfaced all three.

## Test plan
- [x] `create_branch` emits `-B`, never `-b`
- [x] `_should_open_pr` gates on branch **and** diff; `quality_gates → open_pr` edge is gone, `check_pr → open_pr` exists
- [x] Loop stops after one retry on a repeated no-PR task; keeps draining when tasks differ; unaffected when PRs are produced
- [x] Full suite: 2252 passing
- [ ] Post-deploy: re-run the targeted cycle on #173