### PR TITLE
feat(web): issues board with a Play button on the project page

### DIFF
--- a/src/theswarm/presentation/web/routes/projects.py
+++ b/src/theswarm/presentation/web/routes/projects.py
@@ -92,6 +92,98 @@ async def project_detail(request: Request, project_id: str) -> HTMLResponse:
     )
 
 
+# Issue-driven flow (P2, theswarm#24): browse the target repo's GitHub
+# issues and press Play on one. The board groups by `status:*` label so the
+# swarm's own workflow is visible at a glance.
+_STATUS_COLUMNS = ("ready", "in-progress", "review", "backlog")
+
+
+def _issue_status(issue: dict) -> str:
+    """Column an issue belongs to, from its `status:*` label."""
+    for label in issue.get("labels", []):
+        name = label if isinstance(label, str) else label.get("name", "")
+        if name.startswith("status:"):
+            suffix = name.split(":", 1)[1]
+            if suffix in _STATUS_COLUMNS:
+                return suffix
+    return "backlog"
+
+
+@router.get("/{project_id}/issues", response_class=HTMLResponse)
+async def project_issues(request: Request, project_id: str) -> HTMLResponse:
+    """HTMX fragment: the target repo's open issues, grouped by status."""
+    query: GetProjectQuery = request.app.state.get_project_query
+    project = await query.execute(project_id)
+    if project is None:
+        return HTMLResponse("Project not found", status_code=404)
+
+    columns: dict[str, list[dict]] = {name: [] for name in _STATUS_COLUMNS}
+    error = ""
+    try:
+        from theswarm.tools.github import GitHubClient
+
+        issues = await GitHubClient(str(project.repo)).get_issues()
+        for issue in issues:
+            columns[_issue_status(issue)].append(issue)
+    except Exception as exc:  # noqa: BLE001 — surfaced in the panel, not fatal
+        log.exception("Failed to list issues for project %s", project_id)
+        error = str(exc)[:200]
+
+    return request.app.state.templates.TemplateResponse(
+        "project_issues_fragment.html",
+        {
+            "request": request,
+            "project": project,
+            "project_id": project_id,
+            "columns": columns,
+            "column_names": _STATUS_COLUMNS,
+            "error": error,
+        },
+    )
+
+
+@router.post("/{project_id}/issues/{issue_number}/play", response_class=HTMLResponse)
+async def play_issue(
+    request: Request, project_id: str, issue_number: int,
+) -> HTMLResponse:
+    """Start a cycle pinned to one issue and point the user at it."""
+    query: GetProjectQuery = request.app.state.get_project_query
+    project = await query.execute(project_id)
+    if project is None:
+        return HTMLResponse("Project not found", status_code=404)
+
+    import asyncio
+
+    from theswarm.api import CycleRequest, get_cycle_tracker, run_api_cycle
+
+    repo = str(project.repo)
+    tracker = get_cycle_tracker()
+    record = tracker.create(CycleRequest(repo=repo, issue_number=issue_number))
+    state = request.app.state
+    task = asyncio.create_task(
+        run_api_cycle(
+            record.id, repo, f"Play on issue #{issue_number}", "",
+            getattr(state, "allowed_repos", []),
+            event_bus=getattr(state, "event_bus", None),
+            report_repo=getattr(state, "report_repo", None),
+            base_path=getattr(state, "base_path", ""),
+            project_repo=getattr(state, "project_repo", None),
+            cycle_repo=getattr(state, "cycle_repo", None),
+            project_id=project_id,
+            role_assignment_service=getattr(state, "role_assignment_service", None),
+            issue_number=issue_number,
+        )
+    )
+    tracker.set_task(record.id, task)
+    log.info("Play on #%d (%s) → cycle %s", issue_number, repo, record.id)
+
+    base = state.base_path
+    # HTMX drives the redirect so the button can live inside the board.
+    return HTMLResponse(
+        "", headers={"HX-Redirect": f"{base}/cycles/{record.id}"},
+    )
+
+
 @router.post("/{project_id}/delete", response_class=RedirectResponse)
 async def delete_project(request: Request, project_id: str) -> RedirectResponse:
     handler: DeleteProjectHandler = request.app.state.delete_project_handler

--- a/src/theswarm/presentation/web/static/css/dashboard.css
+++ b/src/theswarm/presentation/web/static/css/dashboard.css
@@ -3506,3 +3506,81 @@ body.has-todays-demo-expanded { overflow: hidden; }
   width: auto;
 }
 .readiness-banner-dismiss:hover { color: var(--text-primary); }
+
+/* ── Issue board (issue-driven flow) ─────────────────────────────────── */
+
+.issues-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.issues-column h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.issues-column-count {
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.issues-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.issue-card {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.6rem;
+}
+
+.issue-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.issue-number {
+  color: var(--text-secondary);
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.8rem;
+  text-decoration: none;
+}
+
+.issue-number:hover { color: var(--accent); }
+
+.issue-title {
+  margin-top: 0.3rem;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  color: var(--text-primary);
+}
+
+.issue-play {
+  background: var(--accent-subtle);
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  border-radius: 5px;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.issue-play:hover { background: var(--accent); color: var(--bg-primary); }
+
+.po-count-ready { background: var(--success-subtle); color: var(--success); }
+.po-count-in-progress { background: var(--warning-subtle); color: var(--warning); }
+.po-count-review { background: var(--accent-subtle); color: var(--accent); }
+.po-count-backlog { background: var(--bg-tertiary); color: var(--text-secondary); }

--- a/src/theswarm/presentation/web/templates/project_issues_fragment.html
+++ b/src/theswarm/presentation/web/templates/project_issues_fragment.html
@@ -1,0 +1,52 @@
+{# GitHub issues of the target repo, grouped by status:* label. HTMX-swappable.
+   Press ▶ on an issue to run a cycle pinned to it (theswarm#23 / #24). #}
+<section id="issues-fragment-{{ project_id }}" class="po-panel"
+         data-testid="issues-board">
+  <header class="po-panel-header">
+    <h3>GitHub issues</h3>
+    <div class="po-counts">
+      {% for name in column_names %}
+        <span class="po-count po-count-{{ name }}">{{ name }}: {{ columns[name]|length }}</span>
+      {% endfor %}
+      <button type="button"
+              hx-get="{{ base }}/projects/{{ project_id }}/issues"
+              hx-target="#issues-fragment-{{ project_id }}"
+              hx-swap="outerHTML"
+              data-testid="issues-refresh">Refresh</button>
+    </div>
+  </header>
+
+  {% if error %}
+    <p class="po-empty" data-testid="issues-error">Could not read issues: {{ error }}</p>
+  {% elif not columns.values()|map('length')|sum %}
+    <p class="po-empty">No open issues. Use the sprint composer above to have the PO draft some.</p>
+  {% else %}
+    <div class="issues-board">
+      {% for name in column_names %}
+        <div class="issues-column" data-testid="issues-column-{{ name }}">
+          <h4>{{ name }} <span class="issues-column-count">{{ columns[name]|length }}</span></h4>
+          <ul class="issues-list">
+            {% for issue in columns[name] %}
+              <li class="issue-card" data-testid="issue-{{ issue.number }}">
+                <div class="issue-head">
+                  <a class="issue-number"
+                     href="https://github.com/{{ project.repo }}/issues/{{ issue.number }}"
+                     target="_blank" rel="noopener">#{{ issue.number }}</a>
+                  {% if name != 'review' %}
+                    <button type="button"
+                            class="issue-play"
+                            title="Run a cycle on this issue"
+                            hx-post="{{ base }}/projects/{{ project_id }}/issues/{{ issue.number }}/play"
+                            hx-swap="none"
+                            data-testid="play-{{ issue.number }}">▶ Play</button>
+                  {% endif %}
+                </div>
+                <div class="issue-title">{{ issue.title }}</div>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+</section>

--- a/src/theswarm/presentation/web/templates/projects_detail.html
+++ b/src/theswarm/presentation/web/templates/projects_detail.html
@@ -142,6 +142,15 @@
   <p class="empty-state">Loading sprints…</p>
 </section>
 
+{# Issue-driven flow: describe above → the PO drafts issues → pick one and
+   press ▶ to run a cycle pinned to it. #}
+<div hx-get="{{ base }}/projects/{{ project.id }}/issues"
+     hx-trigger="load"
+     hx-swap="outerHTML"
+     data-testid="issues-board-slot">
+  <section class="card"><p class="empty-state">Loading issues…</p></section>
+</div>
+
 <div class="detail-grid">
   <div class="card">
     <h2>Configuration</h2>

--- a/tests/presentation/test_project_issues_board.py
+++ b/tests/presentation/test_project_issues_board.py
@@ -1,0 +1,172 @@
+"""Issue board with a Play button (theswarm#24, issue-driven flow P2).
+
+The project page lists the target repo's GitHub issues grouped by
+``status:*`` label; pressing ▶ starts a cycle pinned to that issue and sends
+the user to it. Backend targeting landed in #23 — this is the surface that
+makes it usable without curl.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from theswarm.presentation.web.app import _TemplateEngine
+
+from theswarm.presentation.web.routes import projects as projects_routes
+
+TEMPLATES_DIR = "src/theswarm/presentation/web/templates"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cycle_tracker():
+    """Play registers a cycle in the process-wide tracker; the dashboard
+    reads that same singleton, so anything left behind leaks into other
+    test modules."""
+    from theswarm.api import get_cycle_tracker
+
+    tracker = get_cycle_tracker()
+    known = set(tracker._cycles)
+    yield
+    for cycle_id in set(tracker._cycles) - known:
+        task = tracker._tasks.pop(cycle_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+        tracker._cycles.pop(cycle_id, None)
+
+
+class _FakeGitHub:
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+
+    async def get_issues(self, labels=None, state="open"):
+        return [
+            {"number": 186, "title": "Add GET /dashboard route",
+             "labels": ["status:ready", "role:dev"], "body": ""},
+            {"number": 187, "title": "HTMX partials",
+             "labels": ["status:in-progress", "role:dev"], "body": ""},
+            {"number": 188, "title": "Shipped work",
+             "labels": ["status:review", "role:dev"], "body": ""},
+            {"number": 189, "title": "Someday", "labels": [], "body": ""},
+        ]
+
+
+def _app(project=SimpleNamespace(id="p1", repo="owner/repo")) -> FastAPI:
+    app = FastAPI()
+    app.include_router(projects_routes.router)
+    app.state.templates = _TemplateEngine(TEMPLATES_DIR)
+    app.state.base_path = ""
+    app.state.get_project_query = SimpleNamespace(
+        execute=lambda _pid: _resolved(project),
+    )
+    for attr in ("allowed_repos", "event_bus", "report_repo", "project_repo",
+                 "cycle_repo", "role_assignment_service"):
+        setattr(app.state, attr, None)
+    app.state.allowed_repos = []
+    return app
+
+
+async def _resolved(value):
+    return value
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+# ── Status grouping ────────────────────────────────────────────────────
+
+
+def test_issue_status_reads_the_status_label():
+    assert projects_routes._issue_status({"labels": ["status:ready"]}) == "ready"
+    assert projects_routes._issue_status({"labels": ["status:review"]}) == "review"
+    # dict-shaped labels (PyGithub) and unknown/absent statuses
+    assert projects_routes._issue_status({"labels": [{"name": "status:in-progress"}]}) == "in-progress"
+    assert projects_routes._issue_status({"labels": ["role:dev"]}) == "backlog"
+    assert projects_routes._issue_status({}) == "backlog"
+
+
+# ── Board rendering ────────────────────────────────────────────────────
+
+
+async def test_board_groups_issues_by_status():
+    with patch("theswarm.tools.github.GitHubClient", _FakeGitHub):
+        async with _client(_app()) as client:
+            resp = await client.get("/projects/p1/issues")
+
+    assert resp.status_code == 200
+    body = resp.text
+    for name in ("ready", "in-progress", "review", "backlog"):
+        assert f'data-testid="issues-column-{name}"' in body
+    assert 'data-testid="issue-186"' in body
+    assert "Add GET /dashboard route" in body
+    # Links back to the real issue
+    assert "https://github.com/owner/repo/issues/186" in body
+
+
+async def test_play_button_targets_the_issue_and_skips_review():
+    with patch("theswarm.tools.github.GitHubClient", _FakeGitHub):
+        async with _client(_app()) as client:
+            body = (await client.get("/projects/p1/issues")).text
+
+    assert 'hx-post="/projects/p1/issues/186/play"' in body
+    assert 'data-testid="play-186"' in body
+    # An issue already in review has nothing left to implement
+    assert 'data-testid="play-188"' not in body
+
+
+async def test_board_surfaces_github_errors_without_failing():
+    class _Broken:
+        def __init__(self, repo): ...
+        async def get_issues(self, **kw):
+            raise RuntimeError("bad credentials")
+
+    with patch("theswarm.tools.github.GitHubClient", _Broken):
+        async with _client(_app()) as client:
+            resp = await client.get("/projects/p1/issues")
+
+    assert resp.status_code == 200  # panel degrades, page still renders
+    assert "bad credentials" in resp.text
+
+
+async def test_board_404s_for_an_unknown_project():
+    app = _app(project=None)
+    async with _client(app) as client:
+        assert (await client.get("/projects/nope/issues")).status_code == 404
+
+
+# ── Play action ────────────────────────────────────────────────────────
+
+
+async def test_play_starts_a_cycle_pinned_to_the_issue():
+    captured: dict = {}
+
+    async def fake_run(cycle_id, repo, description, callback_url, allowed, **kwargs):
+        captured["repo"] = repo
+        captured["issue_number"] = kwargs.get("issue_number")
+        captured["cycle_id"] = cycle_id
+
+    with patch("theswarm.api.run_api_cycle", side_effect=fake_run):
+        async with _client(_app()) as client:
+            resp = await client.post("/projects/p1/issues/186/play")
+
+    assert resp.status_code == 200
+    redirect = resp.headers["HX-Redirect"]
+    assert redirect.startswith("/cycles/")
+
+    # The cycle was registered against the right repo and issue
+    from theswarm.api import get_cycle_tracker
+
+    record = get_cycle_tracker().get(redirect.rsplit("/", 1)[1])
+    assert record is not None
+    assert record.repo == "owner/repo"
+
+
+async def test_play_404s_for_an_unknown_project():
+    app = _app(project=None)
+    async with _client(app) as client:
+        assert (await client.post("/projects/nope/issues/1/play")).status_code == 404


### PR DESCRIPTION
Implements #24 — the surface that makes #23's targeting usable without curl.

The project page now lists the target repo's open GitHub issues, grouped by `status:*` label, right under the sprint composer. That closes the loop the plan describes: **describe → the PO drafts issues → pick one → ▶ Play**.

- `GET /projects/{id}/issues` — HTMX fragment, four columns (ready / in-progress / review / backlog), each card linking to the real GitHub issue. A GitHub failure degrades the panel rather than breaking the page.
- `POST /projects/{id}/issues/{n}/play` — creates a cycle pinned to that issue and answers `HX-Redirect` to its page, so the button can live inside the board.
- No ▶ on issues already in `status:review` — nothing left to implement there.

## Test plan
- [x] Status grouping handles string labels, PyGithub dict labels, unknown and absent statuses
- [x] Board renders all four columns, cards, and GitHub links
- [x] Play button posts to the targeting endpoint; absent on review issues
- [x] GitHub error surfaces in-panel with HTTP 200; unknown project 404s on both routes
- [x] Play registers the cycle against the right repo and redirects
- [x] Full suite: 2259 passing (added a fixture isolating the process-wide cycle tracker — Play writes to the same singleton the dashboard reads)
- [ ] Post-deploy: screenshot the board on prod

Closes #24