### PR TITLE
feat(web): show what a targeted cycle is building, and how it was split

### DIFF
--- a/src/theswarm/api.py
+++ b/src/theswarm/api.py
@@ -46,6 +46,7 @@ class CycleRecord(BaseModel):
     repo: str
     description: str
     callback_url: str
+    issue_number: int | None = None
     status: CycleStatus
     created_at: str
     started_at: str = ""
@@ -68,6 +69,7 @@ class CycleTracker:
             repo=req.repo,
             description=req.description,
             callback_url=req.callback_url,
+            issue_number=req.issue_number,
             status=CycleStatus.QUEUED,
             created_at=datetime.now().isoformat(timespec="seconds"),
         )

--- a/src/theswarm/presentation/web/routes/fragments.py
+++ b/src/theswarm/presentation/web/routes/fragments.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
 from theswarm.application.queries.get_cycle_status import GetCycleStatusQuery
 from theswarm.application.queries.get_dashboard import GetDashboardQuery
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/fragments")
 
@@ -114,6 +118,67 @@ async def cycle_live_progress_fragment(request: Request, cycle_id: str) -> HTMLR
     return templates.TemplateResponse(
         "partials/_cycle_live_progress.html",
         {"request": request, "rows": rows},
+    )
+
+
+@router.get("/cycle/{cycle_id}/issue", response_class=HTMLResponse)
+async def cycle_issue_fragment(request: Request, cycle_id: str) -> HTMLResponse:
+    """What a targeted cycle is building: the pinned issue and its breakdown.
+
+    Issue-driven flow P3 (theswarm#25). The TechLead breakdown already
+    creates sub-issues carrying ``Parent: #N``; this reads them back so the
+    page answers 'the feature was split into X tasks, here is where each
+    one stands' while the cycle runs.
+    """
+    from theswarm.api import get_cycle_tracker
+
+    record = get_cycle_tracker().get(cycle_id)
+    context: dict = {
+        "request": request,
+        "cycle_id": cycle_id,
+        "issue": None,
+        "children": [],
+        "done": 0,
+        "repo": "",
+        "error": "",
+    }
+
+    if record is None or record.issue_number is None:
+        # Untargeted (or DB-backed) cycle: nothing to pin, render nothing.
+        return request.app.state.templates.TemplateResponse(
+            "partials/_cycle_issue.html", context,
+        )
+
+    context["repo"] = record.repo
+    try:
+        from theswarm.tools.github import GitHubClient
+
+        client = GitHubClient(record.repo)
+        issue = await client.get_issue(record.issue_number)
+        context["issue"] = issue
+        if issue is not None:
+            from theswarm.tools.github import issue_status
+
+            marker = f"Parent: #{record.issue_number}"
+            everything = await client.get_issues(state="all")
+            children = [
+                {
+                    "number": child["number"],
+                    "title": child["title"],
+                    "status": issue_status(child),
+                }
+                for child in everything
+                if marker in (child.get("body") or "")
+            ]
+            context["children"] = children
+            context["done"] = sum(1 for c in children if c["status"] == "review")
+    except Exception as exc:  # noqa: BLE001 — degrade the panel, not the page
+        log.exception("Failed to read issue %s for cycle %s",
+                      record.issue_number, cycle_id)
+        context["error"] = str(exc)[:200]
+
+    return request.app.state.templates.TemplateResponse(
+        "partials/_cycle_issue.html", context,
     )
 
 

--- a/src/theswarm/presentation/web/routes/projects.py
+++ b/src/theswarm/presentation/web/routes/projects.py
@@ -95,18 +95,8 @@ async def project_detail(request: Request, project_id: str) -> HTMLResponse:
 # Issue-driven flow (P2, theswarm#24): browse the target repo's GitHub
 # issues and press Play on one. The board groups by `status:*` label so the
 # swarm's own workflow is visible at a glance.
-_STATUS_COLUMNS = ("ready", "in-progress", "review", "backlog")
-
-
-def _issue_status(issue: dict) -> str:
-    """Column an issue belongs to, from its `status:*` label."""
-    for label in issue.get("labels", []):
-        name = label if isinstance(label, str) else label.get("name", "")
-        if name.startswith("status:"):
-            suffix = name.split(":", 1)[1]
-            if suffix in _STATUS_COLUMNS:
-                return suffix
-    return "backlog"
+from theswarm.tools.github import STATUS_VALUES as _STATUS_COLUMNS
+from theswarm.tools.github import issue_status as _issue_status
 
 
 @router.get("/{project_id}/issues", response_class=HTMLResponse)

--- a/src/theswarm/presentation/web/static/css/dashboard.css
+++ b/src/theswarm/presentation/web/static/css/dashboard.css
@@ -3584,3 +3584,80 @@ body.has-todays-demo-expanded { overflow: hidden; }
 .po-count-in-progress { background: var(--warning-subtle); color: var(--warning); }
 .po-count-review { background: var(--accent-subtle); color: var(--accent); }
 .po-count-backlog { background: var(--bg-tertiary); color: var(--text-secondary); }
+
+/* ── Targeted issue panel on the cycle page ──────────────────────────── */
+
+.cycle-issue {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.cycle-issue-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.cycle-issue-link {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.cycle-issue-title {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cycle-issue-summary {
+  margin: 0.4rem 0 0.6rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.cycle-issue-children {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cycle-issue-child {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.cycle-issue-child a {
+  color: var(--text-secondary);
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  text-decoration: none;
+}
+
+.cycle-issue-child a:hover { color: var(--accent); }
+
+.cycle-issue-child-title { color: var(--text-primary); }
+
+.chip {
+  display: inline-block;
+  min-width: 5.5rem;
+  text-align: center;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.chip-ready { background: var(--success-subtle); color: var(--success); }
+.chip-in-progress { background: var(--warning-subtle); color: var(--warning); }
+.chip-review { background: var(--accent-subtle); color: var(--accent); }
+.chip-backlog { background: var(--bg-tertiary); color: var(--text-secondary); }

--- a/src/theswarm/presentation/web/templates/cycles_detail.html
+++ b/src/theswarm/presentation/web/templates/cycles_detail.html
@@ -30,6 +30,12 @@
     </div>
   </div>
 
+  {# Issue-driven flow: what this cycle is building, and how it was split. #}
+  <div hx-get="{{ base }}/fragments/cycle/{{ cycle.id }}/issue"
+       hx-trigger="load{% if cycle.status == 'running' %}, every 15s{% endif %}"
+       hx-swap="innerHTML"
+       data-testid="cycle-issue-slot"></div>
+
   <div class="detail-grid">
     <div class="card">
       <h2>Overview</h2>

--- a/src/theswarm/presentation/web/templates/partials/_cycle_issue.html
+++ b/src/theswarm/presentation/web/templates/partials/_cycle_issue.html
@@ -1,0 +1,33 @@
+{# What a targeted cycle is building: the pinned issue and its breakdown.
+   Renders nothing for an untargeted cycle (theswarm#25). #}
+{% if error %}
+  <p class="empty-state" data-testid="cycle-issue-error">Could not read the issue: {{ error }}</p>
+{% elif issue %}
+  <div class="cycle-issue" data-testid="cycle-issue">
+    <div class="cycle-issue-head">
+      <a class="cycle-issue-link"
+         href="https://github.com/{{ repo }}/issues/{{ issue.number }}"
+         target="_blank" rel="noopener">#{{ issue.number }}</a>
+      <span class="cycle-issue-title">{{ issue.title }}</span>
+    </div>
+
+    {% if children %}
+      <p class="cycle-issue-summary" data-testid="breakdown-summary">
+        Split into {{ children | length }} task{{ '' if children | length == 1 else 's' }}
+        — {{ done }} in review
+      </p>
+      <ul class="cycle-issue-children">
+        {% for child in children %}
+          <li class="cycle-issue-child" data-testid="child-{{ child.number }}">
+            <span class="chip chip-{{ child.status }}">{{ child.status }}</span>
+            <a href="https://github.com/{{ repo }}/issues/{{ child.number }}"
+               target="_blank" rel="noopener">#{{ child.number }}</a>
+            <span class="cycle-issue-child-title">{{ child.title }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="cycle-issue-summary">Not broken down — implemented directly.</p>
+    {% endif %}
+  </div>
+{% endif %}

--- a/src/theswarm/tools/github.py
+++ b/src/theswarm/tools/github.py
@@ -246,6 +246,20 @@ class GitHubClient:
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
+STATUS_VALUES = ("ready", "in-progress", "review", "backlog")
+
+
+def issue_status(issue: dict) -> str:
+    """Workflow column an issue dict belongs to, from its `status:*` label."""
+    for label in issue.get("labels", []):
+        name = label if isinstance(label, str) else label.get("name", "")
+        if name.startswith("status:"):
+            suffix = name.split(":", 1)[1]
+            if suffix in STATUS_VALUES:
+                return suffix
+    return "backlog"
+
+
 def _is_pull_request(issue: Issue) -> bool:
     """True when the issues endpoint returned a PR rather than an issue.
 

--- a/tests/presentation/test_cycle_issue_panel.py
+++ b/tests/presentation/test_cycle_issue_panel.py
@@ -1,0 +1,161 @@
+"""Cycle page shows what a targeted cycle is building (theswarm#25, P3).
+
+The TechLead breakdown already creates sub-issues carrying ``Parent: #N``
+and QA already stores per-story artifacts; none of it reached the UI. This
+panel answers, while the cycle runs: which issue is being built, how it was
+split, and where each sub-task stands.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from theswarm.api import CycleRequest, get_cycle_tracker
+from theswarm.presentation.web.app import _TemplateEngine
+from theswarm.presentation.web.routes import fragments as fragments_routes
+
+TEMPLATES_DIR = "src/theswarm/presentation/web/templates"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tracker():
+    tracker = get_cycle_tracker()
+    known = set(tracker._cycles)
+    yield
+    for cycle_id in set(tracker._cycles) - known:
+        tracker._cycles.pop(cycle_id, None)
+
+
+class _FakeGitHub:
+    """Repo with one parent story broken into three tasks."""
+
+    CHILDREN = [
+        {"number": 201, "title": "Model", "body": "…\n\nParent: #200",
+         "labels": ["role:dev", "status:review"], "state": "closed"},
+        {"number": 202, "title": "Endpoint", "body": "…\n\nParent: #200",
+         "labels": ["role:dev", "status:in-progress"], "state": "open"},
+        {"number": 203, "title": "Tests", "body": "…\n\nParent: #200",
+         "labels": ["role:dev", "status:ready"], "state": "open"},
+        {"number": 999, "title": "Unrelated", "body": "no parent here",
+         "labels": ["status:ready"], "state": "open"},
+    ]
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+
+    async def get_issue(self, number: int):
+        if number == 200:
+            return {"number": 200, "title": "Tour dashboard",
+                    "labels": ["status:in-progress"], "body": "", "state": "open"}
+        return None
+
+    async def get_issues(self, labels=None, state="open"):
+        return list(self.CHILDREN)
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(fragments_routes.router)
+    app.state.templates = _TemplateEngine(TEMPLATES_DIR)
+    app.state.base_path = ""
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _targeted_cycle(issue_number: int | None):
+    return get_cycle_tracker().create(
+        CycleRequest(repo="owner/repo", issue_number=issue_number),
+    )
+
+
+# ── The tracker has to remember the target ─────────────────────────────
+
+
+def test_tracker_remembers_the_targeted_issue():
+    assert _targeted_cycle(200).issue_number == 200
+    assert _targeted_cycle(None).issue_number is None
+
+
+# ── Panel ──────────────────────────────────────────────────────────────
+
+
+async def test_panel_shows_the_issue_and_its_breakdown(monkeypatch):
+    monkeypatch.setattr("theswarm.tools.github.GitHubClient", _FakeGitHub)
+    record = _targeted_cycle(200)
+
+    async with _client(_app()) as client:
+        body = (await client.get(f"/fragments/cycle/{record.id}/issue")).text
+
+    assert 'data-testid="cycle-issue"' in body
+    assert "Tour dashboard" in body
+    assert "https://github.com/owner/repo/issues/200" in body
+    # Three children, the unrelated issue excluded
+    assert "Split into 3 tasks" in body
+    assert "1 in review" in body
+    for number in (201, 202, 203):
+        assert f'data-testid="child-{number}"' in body
+    assert 'data-testid="child-999"' not in body
+
+
+async def test_panel_renders_a_status_chip_per_child(monkeypatch):
+    monkeypatch.setattr("theswarm.tools.github.GitHubClient", _FakeGitHub)
+    record = _targeted_cycle(200)
+
+    async with _client(_app()) as client:
+        body = (await client.get(f"/fragments/cycle/{record.id}/issue")).text
+
+    for chip in ("chip-review", "chip-in-progress", "chip-ready"):
+        assert chip in body
+
+
+async def test_panel_is_empty_for_an_untargeted_cycle():
+    record = _targeted_cycle(None)
+
+    async with _client(_app()) as client:
+        resp = await client.get(f"/fragments/cycle/{record.id}/issue")
+
+    assert resp.status_code == 200
+    assert 'data-testid="cycle-issue"' not in resp.text
+
+
+async def test_panel_is_empty_for_an_unknown_cycle():
+    async with _client(_app()) as client:
+        resp = await client.get("/fragments/cycle/deadbeef/issue")
+
+    assert resp.status_code == 200
+    assert 'data-testid="cycle-issue"' not in resp.text
+
+
+async def test_panel_reports_a_task_implemented_directly(monkeypatch):
+    class _NoChildren(_FakeGitHub):
+        async def get_issues(self, labels=None, state="open"):
+            return []
+
+    monkeypatch.setattr("theswarm.tools.github.GitHubClient", _NoChildren)
+    record = _targeted_cycle(200)
+
+    async with _client(_app()) as client:
+        body = (await client.get(f"/fragments/cycle/{record.id}/issue")).text
+
+    assert "implemented directly" in body
+
+
+async def test_panel_degrades_when_github_fails(monkeypatch):
+    class _Broken:
+        def __init__(self, repo): ...
+        async def get_issue(self, number):
+            raise RuntimeError("rate limited")
+
+    monkeypatch.setattr("theswarm.tools.github.GitHubClient", _Broken)
+    record = _targeted_cycle(200)
+
+    async with _client(_app()) as client:
+        resp = await client.get(f"/fragments/cycle/{record.id}/issue")
+
+    assert resp.status_code == 200
+    assert "rate limited" in resp.text


### PR DESCRIPTION
Implements #25 — the 'follow the implementation visually' half of the objective.

The pipeline already produced this information and threw it away: the TechLead breakdown creates sub-issues carrying `Parent: #N`, but the cycle page never said which issue was being built, let alone how it had been split.

- `CycleRecord` remembers `issue_number`, so a cycle knows its own target.
- `GET /fragments/cycle/{id}/issue` renders the pinned issue (linked to GitHub), then its `Parent: #N` children with a **live status chip each** and an *"Split into X tasks — N in review"* summary. Polls every 15s while the cycle runs, once otherwise.
- Untargeted cycles render nothing; a GitHub failure degrades the panel, not the page.
- `issue_status` moves next to the issue serializer in `tools/github`, shared with the board from #24 instead of duplicated in the routes.

## Test plan
- [x] Tracker remembers the target (and `None` when untargeted)
- [x] Panel shows the issue, its GitHub link, the 3 children, the review count — and excludes an unrelated issue with no `Parent:` marker
- [x] One status chip per child (review / in-progress / ready)
- [x] Empty for untargeted and unknown cycles; "implemented directly" when not broken down
- [x] GitHub failure surfaces in-panel with HTTP 200
- [x] Full suite: 2270 passing
- [ ] Post-deploy: screenshot the panel on a real targeted cycle

Closes #25