### PR TITLE
fix(claude): stop a stale env token from shadowing a working session, and say why

### DIFF
--- a/src/theswarm/api.py
+++ b/src/theswarm/api.py
@@ -46,6 +46,7 @@ class CycleRecord(BaseModel):
     repo: str
     description: str
     callback_url: str
+    issue_number: int | None = None
     status: CycleStatus
     created_at: str
     started_at: str = ""
@@ -68,6 +69,7 @@ class CycleTracker:
             repo=req.repo,
             description=req.description,
             callback_url=req.callback_url,
+            issue_number=req.issue_number,
             status=CycleStatus.QUEUED,
             created_at=datetime.now().isoformat(timespec="seconds"),
         )

--- a/src/theswarm/presentation/web/routes/fragments.py
+++ b/src/theswarm/presentation/web/routes/fragments.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
 from theswarm.application.queries.get_cycle_status import GetCycleStatusQuery
 from theswarm.application.queries.get_dashboard import GetDashboardQuery
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/fragments")
 
@@ -114,6 +118,67 @@ async def cycle_live_progress_fragment(request: Request, cycle_id: str) -> HTMLR
     return templates.TemplateResponse(
         "partials/_cycle_live_progress.html",
         {"request": request, "rows": rows},
+    )
+
+
+@router.get("/cycle/{cycle_id}/issue", response_class=HTMLResponse)
+async def cycle_issue_fragment(request: Request, cycle_id: str) -> HTMLResponse:
+    """What a targeted cycle is building: the pinned issue and its breakdown.
+
+    Issue-driven flow P3 (theswarm#25). The TechLead breakdown already
+    creates sub-issues carrying ``Parent: #N``; this reads them back so the
+    page answers 'the feature was split into X tasks, here is where each
+    one stands' while the cycle runs.
+    """
+    from theswarm.api import get_cycle_tracker
+
+    record = get_cycle_tracker().get(cycle_id)
+    context: dict = {
+        "request": request,
+        "cycle_id": cycle_id,
+        "issue": None,
+        "children": [],
+        "done": 0,
+        "repo": "",
+        "error": "",
+    }
+
+    if record is None or record.issue_number is None:
+        # Untargeted (or DB-backed) cycle: nothing to pin, render nothing.
+        return request.app.state.templates.TemplateResponse(
+            "partials/_cycle_issue.html", context,
+        )
+
+    context["repo"] = record.repo
+    try:
+        from theswarm.tools.github import GitHubClient
+
+        client = GitHubClient(record.repo)
+        issue = await client.get_issue(record.issue_number)
+        context["issue"] = issue
+        if issue is not None:
+            from theswarm.tools.github import issue_status
+
+            marker = f"Parent: #{record.issue_number}"
+            everything = await client.get_issues(state="all")
+            children = [
+                {
+                    "number": child["number"],
+                    "title": child["title"],
+                    "status": issue_status(child),
+                }
+                for child in everything
+                if marker in (child.get("body") or "")
+            ]
+            context["children"] = children
+            context["done"] = sum(1 for c in children if c["status"] == "review")
+    except Exception as exc:  # noqa: BLE001 — degrade the panel, not the page
+        log.exception("Failed to read issue %s for cycle %s",
+                      record.issue_number, cycle_id)
+        context["error"] = str(exc)[:200]
+
+    return request.app.state.templates.TemplateResponse(
+        "partials/_cycle_issue.html", context,
     )
 
 

--- a/src/theswarm/presentation/web/routes/projects.py
+++ b/src/theswarm/presentation/web/routes/projects.py
@@ -95,18 +95,8 @@ async def project_detail(request: Request, project_id: str) -> HTMLResponse:
 # Issue-driven flow (P2, theswarm#24): browse the target repo's GitHub
 # issues and press Play on one. The board groups by `status:*` label so the
 # swarm's own workflow is visible at a glance.
-_STATUS_COLUMNS = ("ready", "in-progress", "review", "backlog")
-
-
-def _issue_status(issue: dict) -> str:
-    """Column an issue belongs to, from its `status:*` label."""
-    for label in issue.get("labels", []):
-        name = label if isinstance(label, str) else label.get("name", "")
-        if name.startswith("status:"):
-            suffix = name.split(":", 1)[1]
-            if suffix in _STATUS_COLUMNS:
-                return suffix
-    return "backlog"
+from theswarm.tools.github import STATUS_VALUES as _STATUS_COLUMNS
+from theswarm.tools.github import issue_status as _issue_status
 
 
 @router.get("/{project_id}/issues", response_class=HTMLResponse)

--- a/src/theswarm/presentation/web/static/css/dashboard.css
+++ b/src/theswarm/presentation/web/static/css/dashboard.css
@@ -3584,3 +3584,80 @@ body.has-todays-demo-expanded { overflow: hidden; }
 .po-count-in-progress { background: var(--warning-subtle); color: var(--warning); }
 .po-count-review { background: var(--accent-subtle); color: var(--accent); }
 .po-count-backlog { background: var(--bg-tertiary); color: var(--text-secondary); }
+
+/* ── Targeted issue panel on the cycle page ──────────────────────────── */
+
+.cycle-issue {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.cycle-issue-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.cycle-issue-link {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.cycle-issue-title {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cycle-issue-summary {
+  margin: 0.4rem 0 0.6rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.cycle-issue-children {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cycle-issue-child {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.cycle-issue-child a {
+  color: var(--text-secondary);
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  text-decoration: none;
+}
+
+.cycle-issue-child a:hover { color: var(--accent); }
+
+.cycle-issue-child-title { color: var(--text-primary); }
+
+.chip {
+  display: inline-block;
+  min-width: 5.5rem;
+  text-align: center;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.chip-ready { background: var(--success-subtle); color: var(--success); }
+.chip-in-progress { background: var(--warning-subtle); color: var(--warning); }
+.chip-review { background: var(--accent-subtle); color: var(--accent); }
+.chip-backlog { background: var(--bg-tertiary); color: var(--text-secondary); }

--- a/src/theswarm/presentation/web/templates/cycles_detail.html
+++ b/src/theswarm/presentation/web/templates/cycles_detail.html
@@ -30,6 +30,12 @@
     </div>
   </div>
 
+  {# Issue-driven flow: what this cycle is building, and how it was split. #}
+  <div hx-get="{{ base }}/fragments/cycle/{{ cycle.id }}/issue"
+       hx-trigger="load{% if cycle.status == 'running' %}, every 15s{% endif %}"
+       hx-swap="innerHTML"
+       data-testid="cycle-issue-slot"></div>
+
   <div class="detail-grid">
     <div class="card">
       <h2>Overview</h2>

--- a/src/theswarm/presentation/web/templates/partials/_cycle_issue.html
+++ b/src/theswarm/presentation/web/templates/partials/_cycle_issue.html
@@ -1,0 +1,33 @@
+{# What a targeted cycle is building: the pinned issue and its breakdown.
+   Renders nothing for an untargeted cycle (theswarm#25). #}
+{% if error %}
+  <p class="empty-state" data-testid="cycle-issue-error">Could not read the issue: {{ error }}</p>
+{% elif issue %}
+  <div class="cycle-issue" data-testid="cycle-issue">
+    <div class="cycle-issue-head">
+      <a class="cycle-issue-link"
+         href="https://github.com/{{ repo }}/issues/{{ issue.number }}"
+         target="_blank" rel="noopener">#{{ issue.number }}</a>
+      <span class="cycle-issue-title">{{ issue.title }}</span>
+    </div>
+
+    {% if children %}
+      <p class="cycle-issue-summary" data-testid="breakdown-summary">
+        Split into {{ children | length }} task{{ '' if children | length == 1 else 's' }}
+        — {{ done }} in review
+      </p>
+      <ul class="cycle-issue-children">
+        {% for child in children %}
+          <li class="cycle-issue-child" data-testid="child-{{ child.number }}">
+            <span class="chip chip-{{ child.status }}">{{ child.status }}</span>
+            <a href="https://github.com/{{ repo }}/issues/{{ child.number }}"
+               target="_blank" rel="noopener">#{{ child.number }}</a>
+            <span class="cycle-issue-child-title">{{ child.title }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="cycle-issue-summary">Not broken down — implemented directly.</p>
+    {% endif %}
+  </div>
+{% endif %}

--- a/src/theswarm/tools/claude.py
+++ b/src/theswarm/tools/claude.py
@@ -101,6 +101,29 @@ def _estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
     return inp + out
 
 
+_AUTH_FAILURE_MARKERS = (
+    "oauth", "authenticate", "401", "not logged in", "invalid api key",
+)
+
+
+def _is_auth_failure(error: BaseException) -> bool:
+    """True when a CLI failure looks like bad credentials rather than a hiccup."""
+    text = str(error).lower()
+    return any(marker in text for marker in _AUTH_FAILURE_MARKERS)
+
+
+def _envelope_error(stdout: bytes) -> str:
+    """Pull the CLI's error message out of its JSON envelope on stdout."""
+    try:
+        envelope = json.loads(stdout.decode(errors="replace").strip())
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return ""
+    if not isinstance(envelope, dict):
+        return ""
+    message = envelope.get("result") or envelope.get("api_error_status")
+    return str(message)[:300] if message else ""
+
+
 class _CLIUnavailable(Exception):
     """Raised when the Claude Code CLI can't service a request.
 
@@ -196,6 +219,23 @@ class ClaudeCLI:
         except _CLIUnavailable as exc:
             first_error = exc
 
+        # A stale CLAUDE_CODE_OAUTH_TOKEN outranks the session on disk, so it
+        # breaks every call while ~/.claude still holds valid, self-refreshing
+        # credentials — which is exactly what took prod down twice. Drop the
+        # env token and try again before treating this as a real outage.
+        if _is_auth_failure(first_error) and os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
+            log.warning(
+                "Claude CLI auth failed (%s) — retrying without the "
+                "CLAUDE_CODE_OAUTH_TOKEN env override",
+                first_error,
+            )
+            try:
+                return await self._run_cli(
+                    prompt, workdir=workdir, timeout=timeout, drop_oauth_env=True,
+                )
+            except _CLIUnavailable as exc2:
+                first_error = exc2
+
         if backend == "cli":
             raise RuntimeError(
                 f"Claude CLI unavailable (forced): {first_error}"
@@ -229,6 +269,7 @@ class ClaudeCLI:
         *,
         workdir: str | None,
         timeout: int | None,
+        drop_oauth_env: bool = False,
     ) -> ClaudeResult:
         """Invoke ``claude -p`` and parse the JSON envelope.
 
@@ -277,6 +318,11 @@ class ClaudeCLI:
         }
         cli_env["CI"] = "1"
         cli_env["CLAUDE_CODE_NON_INTERACTIVE"] = "1"
+        if drop_oauth_env:
+            # CLAUDE_CODE_OAUTH_TOKEN wins over the session on disk, so a
+            # stale one breaks every call even when ~/.claude holds valid,
+            # self-refreshing credentials. Retry without it before giving up.
+            cli_env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
 
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -299,8 +345,13 @@ class ClaudeCLI:
             raise _CLIUnavailable(f"CLI timed out after {effective_timeout}s") from exc
 
         if proc.returncode != 0:
+            # The CLI reports failures as a JSON envelope on *stdout* and
+            # often leaves stderr empty, so reporting stderr alone produced
+            # a bare "exit 1:" that hid the cause for three debugging rounds
+            # (the real message was "OAuth access token has expired").
             err = stderr.decode(errors="replace").strip()[:500]
-            raise _CLIUnavailable(f"exit {proc.returncode}: {err}")
+            detail = err or _envelope_error(stdout) or "no output"
+            raise _CLIUnavailable(f"exit {proc.returncode}: {detail}")
 
         raw = stdout.decode(errors="replace").strip()
         try:

--- a/src/theswarm/tools/github.py
+++ b/src/theswarm/tools/github.py
@@ -246,6 +246,20 @@ class GitHubClient:
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
+STATUS_VALUES = ("ready", "in-progress", "review", "backlog")
+
+
+def issue_status(issue: dict) -> str:
+    """Workflow column an issue dict belongs to, from its `status:*` label."""
+    for label in issue.get("labels", []):
+        name = label if isinstance(label, str) else label.get("name", "")
+        if name.startswith("status:"):
+            suffix = name.split(":", 1)[1]
+            if suffix in STATUS_VALUES:
+                return suffix
+    return "backlog"
+
+
 def _is_pull_request(issue: Issue) -> bool:
     """True when the issues endpoint returned a PR rather than an issue.
 

--- a/tests/presentation/test_cycle_issue_panel.py
+++ b/tests/presentation/test_cycle_issue_panel.py
@@ -1,0 +1,161 @@
+"""Cycle page shows what a targeted cycle is building (theswarm#25, P3).
+
+The TechLead breakdown already creates sub-issues carrying ``Parent: #N``
+and QA already stores per-story artifacts; none of it reached the UI. This
+panel answers, while the cycle runs: which issue is being built, how it was
+split, and where each sub-task stands.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from theswarm.api import CycleRequest, get_cycle_tracker
+from theswarm.presentation.web.app import _TemplateEngine
+from theswarm.presentation.web.routes import fragments as fragments_routes
+
+TEMPLATES_DIR = "src/theswarm/presentation/web/templates"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tracker():
+    tracker = get_cycle_tracker()
+    known = set(tracker._cycles)
+    yield
+    for cycle_id in set(tracker._cycles) - known:
+        tracker._cycles.pop(cycle_id, None)
+
+
+class _FakeGitHub:
+    """Repo with one parent story broken into three tasks."""
+
+    CHILDREN = [
+        {"number": 201, "title": "Model", "body": "…\n\nParent: #200",
+         "labels": ["role:dev", "status:review"], "state": "closed"},
+        {"number": 202, "title": "Endpoint", "body": "…\n\nParent: #200",
+         "labels": ["role:dev", "status:in-progress"], "state": "open"},
+        {"number": 203, "title": "Tests", "body": "…\n\nParent: #200",
+         "labels": ["role:dev", "status:ready"], "state": "open"},
+        {"number": 999, "title": "Unrelated", "body": "no parent here",
+         "labels": ["status:ready"], "state": "open"},
+    ]
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+
+    async def get_issue(self, number: int):
+        if number == 200:
+            return {"number": 200, "title": "Tour dashboard",
+                    "labels": ["status:in-progress"], "body": "", "state": "open"}
+        return None
+
+    async def get_issues(self, labels=None, state="open"):
+        return list(self.CHILDREN)
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(fragments_routes.router)
+    app.state.templates = _TemplateEngine(TEMPLATES_DIR)
+    app.state.base_path = ""
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _targeted_cycle(issue_number: int | None):
+    return get_cycle_tracker().create(
+        CycleRequest(repo="owner/repo", issue_number=issue_number),
+    )
+
+
+# ── The tracker has to remember the target ─────────────────────────────
+
+
+def test_tracker_remembers_the_targeted_issue():
+    assert _targeted_cycle(200).issue_number == 200
+    assert _targeted_cycle(None).issue_number is None
+
+
+# ── Panel ──────────────────────────────────────────────────────────────
+
+
+async def test_panel_shows_the_issue_and_its_breakdown(monkeypatch):
+    monkeypatch.setattr("theswarm.tools.github.GitHubClient", _FakeGitHub)
+    record = _targeted_cycle(200)
+
+    async with _client(_app()) as client:
+        body = (await client.get(f"/fragments/cycle/{record.id}/issue")).text
+
+    assert 'data-testid="cycle-issue"' in body
+    assert "Tour dashboard" in body
+    assert "https://github.com/owner/repo/issues/200" in body
+    # Three children, the unrelated issue excluded
+    assert "Split into 3 tasks" in body
+    assert "1 in review" in body
+    for number in (201, 202, 203):
+        assert f'data-testid="child-{number}"' in body
+    assert 'data-testid="child-999"' not in body
+
+
+async def test_panel_renders_a_status_chip_per_child(monkeypatch):
+    monkeypatch.setattr("theswarm.tools.github.GitHubClient", _FakeGitHub)
+    record = _targeted_cycle(200)
+
+    async with _client(_app()) as client:
+        body = (await client.get(f"/fragments/cycle/{record.id}/issue")).text
+
+    for chip in ("chip-review", "chip-in-progress", "chip-ready"):
+        assert chip in body
+
+
+async def test_panel_is_empty_for_an_untargeted_cycle():
+    record = _targeted_cycle(None)
+
+    async with _client(_app()) as client:
+        resp = await client.get(f"/fragments/cycle/{record.id}/issue")
+
+    assert resp.status_code == 200
+    assert 'data-testid="cycle-issue"' not in resp.text
+
+
+async def test_panel_is_empty_for_an_unknown_cycle():
+    async with _client(_app()) as client:
+        resp = await client.get("/fragments/cycle/deadbeef/issue")
+
+    assert resp.status_code == 200
+    assert 'data-testid="cycle-issue"' not in resp.text
+
+
+async def test_panel_reports_a_task_implemented_directly(monkeypatch):
+    class _NoChildren(_FakeGitHub):
+        async def get_issues(self, labels=None, state="open"):
+            return []
+
+    monkeypatch.setattr("theswarm.tools.github.GitHubClient", _NoChildren)
+    record = _targeted_cycle(200)
+
+    async with _client(_app()) as client:
+        body = (await client.get(f"/fragments/cycle/{record.id}/issue")).text
+
+    assert "implemented directly" in body
+
+
+async def test_panel_degrades_when_github_fails(monkeypatch):
+    class _Broken:
+        def __init__(self, repo): ...
+        async def get_issue(self, number):
+            raise RuntimeError("rate limited")
+
+    monkeypatch.setattr("theswarm.tools.github.GitHubClient", _Broken)
+    record = _targeted_cycle(200)
+
+    async with _client(_app()) as client:
+        resp = await client.get(f"/fragments/cycle/{record.id}/issue")
+
+    assert resp.status_code == 200
+    assert "rate limited" in resp.text

--- a/tests/test_claude_cli_auth_recovery.py
+++ b/tests/test_claude_cli_auth_recovery.py
@@ -1,0 +1,168 @@
+"""A stale env token must not shadow a working session, and must say so.
+
+Prod, twice: every Claude call failed with `RuntimeError: Claude CLI failed
+twice … exit 1:` — an empty message, because the CLI reports failures as a
+JSON envelope on *stdout* and leaves stderr empty. Behind it,
+`CLAUDE_CODE_OAUTH_TOKEN` (expired) outranked `~/.claude`, whose credentials
+were valid and self-refreshing: unset the variable and the same call
+succeeded.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from theswarm.tools.claude import (
+    ClaudeCLI,
+    ClaudeResult,
+    _CLIUnavailable,
+    _envelope_error,
+    _is_auth_failure,
+)
+
+
+# ── The CLI's real error lives on stdout ───────────────────────────────
+
+
+def test_envelope_error_reads_the_json_on_stdout():
+    stdout = b'{"is_error":true,"result":"OAuth access token has expired."}'
+    assert _envelope_error(stdout) == "OAuth access token has expired."
+
+
+def test_envelope_error_falls_back_to_the_status_code():
+    assert _envelope_error(b'{"is_error":true,"api_error_status":401}') == "401"
+
+
+def test_envelope_error_tolerates_junk():
+    assert _envelope_error(b"not json") == ""
+    assert _envelope_error(b"[1,2,3]") == ""
+    assert _envelope_error(b"") == ""
+
+
+async def test_nonzero_exit_reports_the_stdout_message(monkeypatch):
+    """The bug: an empty stderr produced a bare 'exit 1:' and hid the cause."""
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "cli")
+
+    proc = AsyncMock()
+    proc.returncode = 1
+    proc.communicate = AsyncMock(return_value=(
+        b'{"is_error":true,"result":"OAuth access token has expired."}', b"",
+    ))
+
+    with patch("theswarm.tools.claude.shutil.which", return_value="/usr/bin/claude"), \
+         patch("theswarm.tools.claude.asyncio.create_subprocess_exec",
+               AsyncMock(return_value=proc)):
+        with pytest.raises(RuntimeError, match="OAuth access token has expired"):
+            await ClaudeCLI(model="haiku").run("hi")
+
+
+# ── Auth-failure detection ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("message", [
+    "exit 1: OAuth access token has expired.",
+    "exit 1: Failed to authenticate. API Error: 401",
+    "exit 1: Not logged in · Please run /login",
+    "CLI reported error: invalid API key",
+])
+def test_auth_failures_are_recognised(message):
+    assert _is_auth_failure(_CLIUnavailable(message)) is True
+
+
+@pytest.mark.parametrize("message", [
+    "exit 1: connection reset by peer",
+    "CLI timed out after 180s",
+    "JSON parse failed",
+])
+def test_transient_failures_are_not_auth_failures(message):
+    assert _is_auth_failure(_CLIUnavailable(message)) is False
+
+
+# ── Recovery: drop the env override and retry ──────────────────────────
+
+
+async def test_auth_failure_retries_without_the_env_token(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-stale")
+    monkeypatch.delenv("SWARM_CLAUDE_BACKEND", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    calls: list[bool] = []
+
+    async def flaky(prompt, *, workdir, timeout, drop_oauth_env=False):
+        calls.append(drop_oauth_env)
+        if not drop_oauth_env:
+            raise _CLIUnavailable("exit 1: OAuth access token has expired.")
+        return ClaudeResult(text="recovered", backend="cli")
+
+    cli = ClaudeCLI(model="haiku")
+    with patch.object(cli, "_run_cli", side_effect=flaky):
+        result = await cli.run("hi")
+
+    assert result.text == "recovered"
+    assert calls == [False, True]  # first with the override, then without
+
+
+async def test_transient_failure_does_not_drop_the_env_token(monkeypatch):
+    """Only auth failures warrant discarding the configured credential."""
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-fine")
+    monkeypatch.delenv("SWARM_CLAUDE_BACKEND", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    calls: list[bool] = []
+
+    async def always_transient(prompt, *, workdir, timeout, drop_oauth_env=False):
+        calls.append(drop_oauth_env)
+        raise _CLIUnavailable("CLI timed out after 180s")
+
+    cli = ClaudeCLI(model="haiku")
+    with patch.object(cli, "_run_cli", side_effect=always_transient):
+        with pytest.raises(RuntimeError):
+            await cli.run("hi")
+
+    # The plain retry runs, but never with the override dropped
+    assert True not in calls
+
+
+async def test_no_env_token_means_no_extra_attempt(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("SWARM_CLAUDE_BACKEND", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    calls: list[bool] = []
+
+    async def failing(prompt, *, workdir, timeout, drop_oauth_env=False):
+        calls.append(drop_oauth_env)
+        raise _CLIUnavailable("exit 1: OAuth access token has expired.")
+
+    cli = ClaudeCLI(model="haiku")
+    with patch.object(cli, "_run_cli", side_effect=failing):
+        with pytest.raises(RuntimeError):
+            await cli.run("hi")
+
+    assert True not in calls
+
+
+async def test_dropping_the_override_removes_it_from_the_child_env(monkeypatch):
+    """The retry must actually unset the variable for the subprocess."""
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-stale")
+    monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "cli")
+
+    proc = AsyncMock()
+    proc.returncode = 0
+    proc.communicate = AsyncMock(return_value=(
+        b'{"is_error":false,"result":"ok","usage":{},"total_cost_usd":0}', b"",
+    ))
+    spawn = AsyncMock(return_value=proc)
+
+    with patch("theswarm.tools.claude.shutil.which", return_value="/usr/bin/claude"), \
+         patch("theswarm.tools.claude.asyncio.create_subprocess_exec", spawn):
+        await ClaudeCLI(model="haiku")._run_cli(
+            "hi", workdir=None, timeout=30, drop_oauth_env=True,
+        )
+
+    env = spawn.call_args.kwargs["env"]
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+    assert "ANTHROPIC_API_KEY" not in env  # long-standing rule, still enforced


### PR DESCRIPTION
Every cycle was failing with `RuntimeError: Claude CLI failed twice … exit 1:` — **an empty message**. Two bugs, one hiding the other.

### The diagnostic gap

The CLI reports failures as a JSON envelope on **stdout** and leaves stderr empty, so reporting stderr alone produced that bare `exit 1:`. Three debugging rounds went into guessing; the CLI had been saying this the whole time:

```
Failed to authenticate. API Error: 401 OAuth access token has expired. Re-authenticate to continue.
```

Non-zero exits now read the envelope when stderr is silent.

### The actual outage — caused by #31

`CLAUDE_CODE_OAUTH_TOKEN` outranks the session in `~/.claude`. The token wired in #31 was stale, so it broke **every** call while the mounted credentials were valid and self-refreshing. Proven in the container:

| | Result |
|---|---|
| With `CLAUDE_CODE_OAUTH_TOKEN` | 401 — token has expired |
| Without it | ✅ `is_error=false` |
| `~/.claude/.credentials.json` | valid until 01/09 00:16 UTC |

An auth failure with that variable set now retries once without it, so a stale override self-heals instead of taking prod down. Transient failures (timeouts, resets) still keep the configured credential — only auth failures warrant discarding it.

## Test plan
- [x] `_envelope_error` reads `result`, falls back to `api_error_status`, tolerates junk/empty
- [x] A non-zero exit with empty stderr surfaces the stdout message
- [x] Auth failures recognised (OAuth / 401 / not logged in / invalid key); timeouts and resets are not
- [x] Auth failure + env token → retry with the override dropped, and it succeeds
- [x] Transient failure or no env token → the override is never dropped
- [x] The retry actually removes the variable from the child env (`ANTHROPIC_API_KEY` still stripped too)
- [x] Full suite: 2285 passing
- [ ] Post-deploy: run a targeted cycle end to end