### PR TITLE
refactor(web): focus the UI on one job — build a feature, follow it

### DIFF
--- a/src/theswarm/presentation/web/routes/dashboard.py
+++ b/src/theswarm/presentation/web/routes/dashboard.py
@@ -3,14 +3,26 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 from theswarm.application.queries.get_dashboard import GetDashboardQuery
 
 router = APIRouter()
 
 
-@router.get("/", response_class=HTMLResponse)
+@router.get("/", response_class=RedirectResponse)
+async def home(request: Request) -> RedirectResponse:
+    """Land on the job: pick a repo, pick an issue, press Play.
+
+    The portfolio dashboard stays reachable under Advanced (/dashboard); it
+    answers 'how is everything going', which is not what someone opening the
+    app is here to do.
+    """
+    base = request.app.state.base_path
+    return RedirectResponse(url=f"{base}/projects/", status_code=307)
+
+
+@router.get("/dashboard", response_class=HTMLResponse)
 async def dashboard(request: Request) -> HTMLResponse:
     query: GetDashboardQuery = request.app.state.get_dashboard_query
     dto = await query.execute()

--- a/src/theswarm/presentation/web/static/css/dashboard.css
+++ b/src/theswarm/presentation/web/static/css/dashboard.css
@@ -3661,3 +3661,33 @@ body.has-todays-demo-expanded { overflow: hidden; }
 .chip-in-progress { background: var(--warning-subtle); color: var(--warning); }
 .chip-review { background: var(--accent-subtle); color: var(--accent); }
 .chip-backlog { background: var(--bg-tertiary); color: var(--text-secondary); }
+
+/* ── Focus mode: primary nav vs collapsed Advanced ───────────────────── */
+
+.nav-primary {
+  list-style: none;
+  margin: 0 0 0.5rem;
+  padding: 0;
+}
+
+.project-advanced {
+  margin-top: 2rem;
+  border-top: 1px solid var(--border);
+  padding-top: 0.75rem;
+}
+
+.project-advanced > summary {
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  padding: 0.35rem 0;
+  list-style: none;
+}
+
+.project-advanced > summary::before {
+  content: "▸ ";
+  color: var(--text-muted);
+}
+
+.project-advanced[open] > summary::before { content: "▾ "; }
+.project-advanced > summary:hover { color: var(--text-primary); }

--- a/src/theswarm/presentation/web/templates/base.html
+++ b/src/theswarm/presentation/web/templates/base.html
@@ -30,45 +30,27 @@
          selectors kept outranking our overrides. Opting out of the tag
          opts out of the whole fight. -->
     <div class="sidebar-nav" role="navigation" aria-label="Main navigation">
-      <details open>
-        <summary>Workspace</summary>
-        <ul>
-          <li><a href="{{ base }}/" data-icon="◇"><span>Dashboard</span></a></li>
-          <li><a href="{{ base }}/projects/" data-icon="▤"><span>Projects</span></a></li>
-          <li><a href="{{ base }}/team" data-icon="◉"><span>Team</span></a></li>
-        </ul>
-      </details>
-
-      <details open>
-        <summary>Activity</summary>
-        <ul>
-          <li><a href="{{ base }}/cycles/" data-icon="↻"><span>Cycles</span></a></li>
-          <li><a href="{{ base }}/chat" data-icon="✉"><span>Chat</span></a></li>
-          <li><a href="{{ base }}/proposals" data-icon="✦"><span>Proposals</span></a></li>
-        </ul>
-      </details>
-
-      <details open>
-        <summary>Output</summary>
-        <ul>
-          <li><a href="{{ base }}/reports/" data-icon="▦"><span>Reports</span></a></li>
-          <li><a href="{{ base }}/demos/" data-icon="▶"><span>Demos</span></a></li>
-          <li><a href="{{ base }}/features/" data-icon="★"><span>Features</span></a></li>
-        </ul>
-      </details>
+      {# The nav answers one job: build a feature and watch it happen.
+         Everything else lives under Advanced, collapsed — the surfaces still
+         exist, they just stop competing with the main path. #}
+      <ul class="nav-primary">
+        <li><a href="{{ base }}/projects/" data-icon="▤"><span>Projects</span></a></li>
+        <li><a href="{{ base }}/cycles/" data-icon="↻"><span>Cycles</span></a></li>
+        <li><a href="{{ base }}/demos/" data-icon="▶"><span>Demos</span></a></li>
+      </ul>
 
       <details>
-        <summary>Roles</summary>
+        <summary>Advanced</summary>
         <ul>
+          <li><a href="{{ base }}/dashboard" data-icon="◇"><span>Dashboard</span></a></li>
+          <li><a href="{{ base }}/team" data-icon="◉"><span>Team</span></a></li>
+          <li><a href="{{ base }}/chat" data-icon="✉"><span>Chat</span></a></li>
+          <li><a href="{{ base }}/proposals" data-icon="✦"><span>Proposals</span></a></li>
+          <li><a href="{{ base }}/reports/" data-icon="▦"><span>Reports</span></a></li>
+          <li><a href="{{ base }}/features/" data-icon="★"><span>Features</span></a></li>
           <li><a href="{{ base }}/architect/paved-road" data-icon="△"><span>Architect</span></a></li>
           <li><a href="{{ base }}/chief-of-staff/routing" data-icon="◈"><span>Chief of Staff</span></a></li>
           <li><a href="{{ base }}/intel/feed" data-icon="◎"><span>Scout</span></a></li>
-        </ul>
-      </details>
-
-      <details>
-        <summary>Knowledge</summary>
-        <ul>
           <li><a href="{{ base }}/semantic-memory" data-icon="❖"><span>Memory</span></a></li>
           <li><a href="{{ base }}/prompt-library" data-icon="❡"><span>Prompts</span></a></li>
           <li><a href="{{ base }}/refactor-programs" data-icon="⟲"><span>Refactors</span></a></li>

--- a/src/theswarm/presentation/web/templates/projects_detail.html
+++ b/src/theswarm/presentation/web/templates/projects_detail.html
@@ -151,6 +151,12 @@
   <section class="card"><p class="empty-state">Loading issues…</p></section>
 </div>
 
+
+{# Everything below answers 'how is this project configured' rather than
+   'build me this feature'. Collapsed so the job above stays the page. #}
+<details class="project-advanced" data-testid="project-advanced">
+  <summary>Advanced — configuration, secrets, and role surfaces</summary>
+
 <div class="detail-grid">
   <div class="card">
     <h2>Configuration</h2>
@@ -525,4 +531,7 @@
   </details>
 
 </section>
+
+</details>
+
 {% endblock %}

--- a/tests/integration/test_ga_smoke.py
+++ b/tests/integration/test_ga_smoke.py
@@ -104,6 +104,7 @@ class TestGASmokeGate:
         # Sprint composer + Run Cycle modal must both be on the page.
         assert "sprint-composer" in r.text
         assert "cost-preview-modal" in r.text
-        # Sidebar entries we shipped in the redesign.
+        # Sidebar: the primary nav is the job itself; the rest is demoted.
         assert "TheSwarm" in r.text
-        assert "<summary>Workspace</summary>" in r.text
+        assert '<ul class="nav-primary">' in r.text
+        assert "<summary>Advanced</summary>" in r.text

--- a/tests/integration/test_unified_server.py
+++ b/tests/integration/test_unified_server.py
@@ -37,7 +37,7 @@ class TestDashboardRoutes:
     """Dashboard and core routes work."""
 
     async def test_dashboard_home(self, client):
-        resp = await client.get("/")
+        resp = await client.get("/dashboard")
         assert resp.status_code == 200
 
     async def test_health(self, client):

--- a/tests/presentation/test_notifications.py
+++ b/tests/presentation/test_notifications.py
@@ -32,7 +32,7 @@ async def test_dashboard_renders_notifications_button(db):
     app = await _mk_app(db)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
-        r = await c.get("/")
+        r = await c.get("/dashboard")
     assert r.status_code == 200
     assert 'id="notifications-toggle"' in r.text
     assert 'data-state="idle"' in r.text

--- a/tests/presentation/test_ui_focus.py
+++ b/tests/presentation/test_ui_focus.py
@@ -1,0 +1,101 @@
+"""The UI answers one job: build a feature and follow it transparently.
+
+17 nav entries, 54 fragments and 16 accordions on the project page buried
+that job. Secondary surfaces are demoted, not deleted — their routes still
+work, they just stop competing with the main path.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+TEMPLATES = Path("src/theswarm/presentation/web/templates")
+BASE = (TEMPLATES / "base.html").read_text()
+PROJECT = (TEMPLATES / "projects_detail.html").read_text()
+
+
+def _primary_nav_links() -> list[str]:
+    block = BASE.split('<ul class="nav-primary">')[1].split("</ul>")[0]
+    return re.findall(r"<span>([^<]+)</span>", block)
+
+
+def _advanced_nav_links() -> list[str]:
+    block = BASE.split("<summary>Advanced</summary>")[1].split("</details>")[0]
+    return re.findall(r"<span>([^<]+)</span>", block)
+
+
+# ── Navigation ─────────────────────────────────────────────────────────
+
+
+def test_primary_nav_is_the_job_and_nothing_else():
+    assert _primary_nav_links() == ["Projects", "Cycles", "Demos"]
+
+
+def test_secondary_surfaces_are_demoted_not_deleted():
+    advanced = _advanced_nav_links()
+    for surface in ("Architect", "Scout", "Memory", "Prompts", "Refactors",
+                    "Chief of Staff", "Proposals", "Dashboard"):
+        assert surface in advanced, f"{surface} should be reachable under Advanced"
+
+
+def test_advanced_group_is_collapsed_by_default():
+    advanced_open = BASE.split("<summary>Advanced</summary>")[0].rstrip().endswith(
+        "<details>",
+    )
+    assert advanced_open, "Advanced must be a plain <details>, not <details open>"
+
+
+# ── Landing page ───────────────────────────────────────────────────────
+
+
+async def test_root_redirects_to_projects():
+    from types import SimpleNamespace
+
+    from theswarm.presentation.web.routes.dashboard import home
+
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(base_path="/swarm")))
+    response = await home(request)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/swarm/projects/"
+
+
+def test_dashboard_stays_reachable_at_its_own_path():
+    source = (Path("src/theswarm/presentation/web/routes/dashboard.py")).read_text()
+    assert '@router.get("/dashboard", response_class=HTMLResponse)' in source
+
+
+# ── Project page ───────────────────────────────────────────────────────
+
+
+def test_the_job_comes_before_the_configuration():
+    """Composer and issue board must precede the Advanced block."""
+    composer = PROJECT.index("Describe the next sprint")
+    board = PROJECT.index('data-testid="issues-board-slot"')
+    advanced = PROJECT.index('data-testid="project-advanced"')
+
+    assert composer < board < advanced
+
+
+def test_configuration_and_roles_live_under_advanced():
+    advanced_block = PROJECT.split('data-testid="project-advanced"')[1]
+    for buried in ("<h2>Configuration</h2>", "<h2>Secrets</h2>",
+                   'data-testid="role-groups"'):
+        assert buried in advanced_block
+
+
+def test_role_panels_are_still_present():
+    """Demoted, not deleted — all fourteen role groups survive."""
+    assert PROJECT.count('class="role-group" data-role=') == 14
+
+
+@pytest.mark.parametrize("slot", [
+    "issues-board-slot",      # pick what to build
+    "sprint-composer",        # describe what to build
+])
+def test_core_surfaces_remain_outside_advanced(slot):
+    before_advanced = PROJECT.split('data-testid="project-advanced"')[0]
+    assert slot in before_advanced

--- a/tests/presentation/test_web_app.py
+++ b/tests/presentation/test_web_app.py
@@ -53,7 +53,7 @@ async def client(app):
 
 class TestDashboardRoutes:
     async def test_dashboard_empty(self, client):
-        r = await client.get("/")
+        r = await client.get("/dashboard")
         assert r.status_code == 200
         assert "TheSwarm" in r.text
         assert "No active cycles" in r.text
@@ -62,7 +62,7 @@ class TestDashboardRoutes:
         project_repo, cycle_repo = repos
         await project_repo.save(Project(id="p1", repo=RepoUrl("o/p1")))
 
-        r = await client.get("/")
+        r = await client.get("/dashboard")
         assert r.status_code == 200
         assert "p1" in r.text
 
@@ -83,7 +83,7 @@ class TestDashboardRoutes:
             ),
         )
 
-        r = await client.get("/")
+        r = await client.get("/dashboard")
         assert r.status_code == 200
         assert r.text.count('class="sparkline"') >= 1 or 'class="sparkline sparkline-empty"' in r.text
 


### PR DESCRIPTION
"L'UI est un vrai bordel. On doit se focus sur une ou deux features, centré sur *je veux que ça dev une feature, et je veux pouvoir le suivre de manière transparente*."

Measured before touching anything: **17 nav entries, 54 HTMX fragments on the project page, 16 accordions**. The job the product exists for was buried under all of it.

**Nothing is deleted.** Every secondary surface keeps its route, its template and its tests — it just stops competing with the main path. Reversible in one line if you want one back.

| | Before | After |
|---|---|---|
| Primary nav entries | 17 | **3** (Projects, Cycles, Demos) + Advanced (12, collapsed) + System |
| Landing page | portfolio dashboard (carousel, Intel forms, KPIs) | **projects list** — pick a repo, pick an issue, press Play |
| Project page top | config, secrets, controls, 14 role accordions | **sprint composer → issue board with ▶** |

The dashboard moves to `/dashboard` (under Advanced): it answers *how is everything going*, which is not what someone opening the app is here to do.

## Test plan
- [x] Primary nav is exactly Projects / Cycles / Demos
- [x] The eight demoted surfaces are all still reachable under Advanced, which is collapsed by default
- [x] `/` redirects (307) to the projects list; `/dashboard` still serves the dashboard
- [x] On the project page: composer < issue board < Advanced; configuration, secrets and role groups sit inside Advanced
- [x] All fourteen role groups survive — demoted, not deleted
- [x] Five dashboard tests and the GA smoke gate retargeted to the new paths
- [x] Full suite: 2295 passing
- [ ] Post-deploy: screenshots of the new landing and project pages