### PR TITLE
feat(web): auth wall — closed by default (#38)

### DIFF
--- a/.github/actions/write-env/action.yml
+++ b/.github/actions/write-env/action.yml
@@ -24,6 +24,10 @@ inputs:
   claude_code_oauth_token:
     required: false
     default: ''
+  swarm_access_key:
+    required: true
+  swarm_session_secret:
+    required: true
 runs:
   using: composite
   steps:
@@ -40,6 +44,8 @@ runs:
         SEQ_API_KEY: ${{ inputs.seq_api_key }}
         SWARM_VAULT_MASTER_KEY: ${{ inputs.swarm_vault_master_key }}
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        SWARM_ACCESS_KEY: ${{ inputs.swarm_access_key }}
+        SWARM_SESSION_SECRET: ${{ inputs.swarm_session_secret }}
       run: |
         {
           echo "MATTERMOST_BOT_TOKEN=$MATTERMOST_BOT_TOKEN"
@@ -53,4 +59,6 @@ runs:
           echo "SEQ_API_KEY=$SEQ_API_KEY"
           echo "SWARM_VAULT_MASTER_KEY=$SWARM_VAULT_MASTER_KEY"
           echo "CLAUDE_CODE_OAUTH_TOKEN=$CLAUDE_CODE_OAUTH_TOKEN"
+          echo "SWARM_ACCESS_KEY=$SWARM_ACCESS_KEY"
+          echo "SWARM_SESSION_SECRET=$SWARM_SESSION_SECRET"
         } > .env

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,6 +90,8 @@ jobs:
           seq_api_key: ${{ secrets.SEQ_API_KEY }}
           swarm_vault_master_key: ${{ secrets.SWARM_VAULT_MASTER_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          swarm_access_key: ${{ secrets.SWARM_ACCESS_KEY }}
+          swarm_session_secret: ${{ secrets.SWARM_SESSION_SECRET }}
       - name: Deploy
         run: |
           export TS_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -157,6 +159,8 @@ jobs:
           seq_api_key: ${{ secrets.SEQ_API_KEY }}
           swarm_vault_master_key: ${{ secrets.SWARM_VAULT_MASTER_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          swarm_access_key: ${{ secrets.SWARM_ACCESS_KEY }}
+          swarm_session_secret: ${{ secrets.SWARM_SESSION_SECRET }}
       - name: Redeploy (latest)
         run: |
           export TS_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,10 @@ fallback; an `sk-ant-oat` OAuth token is CLI-only and is deliberately ignored
 by the fallback), `GITHUB_TOKEN` (push auth,
 injected per git command — never written to `.git/config`), `SWARM_GITHUB_REPO`,
 `MATTERMOST_BOT_TOKEN`, `BASE_PATH` (reverse-proxy prefix, templates use
-`{{ base }}`), `SEQ_URL`/`SEQ_API_KEY` (log aggregation).
+`{{ base }}`), `SEQ_URL`/`SEQ_API_KEY` (log aggregation), `SWARM_ACCESS_KEY`/`SWARM_SESSION_SECRET`
+(dashboard auth wall — fail-safe closed; `SWARM_AUTH_DISABLED=1` opens it for
+local dev/tests only; the access key also works as `Authorization: Bearer` on
+`/api/*`).
 
 ## Deployment
 

--- a/docs/plans/2026-09-v2-one-flow.md
+++ b/docs/plans/2026-09-v2-one-flow.md
@@ -1,0 +1,36 @@
+# V2 — one flow, one screen at a time (2026-09)
+
+Decision (owner, 2026-09-01): the V1 UI stays as-is; V2 is a fresh surface
+focused on a single flow, GitHub-native. Single user for now; public product
+is a later phase (execution isolation + billing are the gate, see the
+product note "La porte d'entrée").
+
+**The flow**: sign in with GitHub → my repos → pick one → write what I want
+(creates a GitHub issue) → the issue appears on the board → ▶ Play →
+a visual, live "theater" of the four agents building it.
+
+## Étapes (each lands as its own PR, deployed and verified in prod)
+
+0. **The lock** — issue #38. Signed-session auth wall, fail-safe closed,
+   access-key login. `SWARM_ACCESS_KEY` / `SWARM_SESSION_SECRET` via repo
+   secrets → write-env → `.env`. Key readable on the server:
+   `~/swarm-access-key.txt`.
+1. **GitHub App** — created via the manifest flow (owner clicks Create +
+   Install; credentials go GitHub → server vault directly). Installation
+   tokens (1 h) replace the static `GITHUB_TOKEN`; "Sign in with GitHub"
+   (App OAuth, owner-only allowlist) joins the access key. New lib: PyJWT.
+2. **V2 shell** — `templates/v2/`, Tailwind v4 standalone binary at Docker
+   build (no node, no CDN), IBM Plex vendored. `/` = repo picker fed by the
+   App installation; picking a repo auto-registers the project.
+3. **Composer + board** — big "what should we build" box → creates the GH
+   issue → appears below with ▶ Play → targeted cycle (existing #25 flow).
+4. **The theater** — live cycle page: four agent stations on a progress
+   rail (SSE), the issue + its breakdown, activity feed; click an agent →
+   its log panel (deeper log UX is its own later feature).
+
+## Non-goals for now
+
+- Multi-user / multi-tenant (needs per-cycle execution isolation)
+- Webhook-triggered cycles, PR-comment loop (after the App exists they get
+  cheap — tracked as follow-ups)
+- Deleting anything from V1

--- a/src/theswarm/application/services/startup_validator.py
+++ b/src/theswarm/application/services/startup_validator.py
@@ -51,6 +51,26 @@ class StartupValidator:
                     "python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
                 )
 
+        # Auth wall (issue #38) — fail-safe closed, so the checks are
+        # about being locked OUT or having knowingly opened up.
+        if os.environ.get("SWARM_AUTH_DISABLED", "").strip().lower() in ("1", "true", "yes"):
+            warnings.append(
+                "SWARM_AUTH_DISABLED is set: the dashboard is OPEN to anyone "
+                "who can reach it. Only acceptable for local dev and tests."
+            )
+        else:
+            if not os.environ.get("SWARM_ACCESS_KEY", "").strip():
+                warnings.append(
+                    "SWARM_ACCESS_KEY not set: the auth wall is up but nobody "
+                    "can log in. Generate one: python -c \"import secrets; "
+                    "print(secrets.token_urlsafe(32))\""
+                )
+            if not os.environ.get("SWARM_SESSION_SECRET", "").strip():
+                warnings.append(
+                    "SWARM_SESSION_SECRET not set: sessions won't survive a "
+                    "restart (an ephemeral secret is generated per boot)."
+                )
+
         # Check for common misconfigs
         repo = os.environ.get("SWARM_GITHUB_REPO", "")
         if repo and "/" not in repo:

--- a/src/theswarm/presentation/web/app.py
+++ b/src/theswarm/presentation/web/app.py
@@ -56,6 +56,8 @@ from theswarm.domain.cycles.events import (
     PhaseChanged,
 )
 from theswarm.presentation.web.routes import analyst, api, architect, artifacts, autonomy_config, chat, chief_of_staff, cycles, dashboard, demos, designer, dev_rigour, features, fragments, health, hitl, metrics, product, projects, prompt_library, qa, refactor_programs, release, reports, scout, security, semantic_memory, settings as settings_route, sre, team, techlead, webhooks, writer
+from theswarm.presentation.web.auth import AuthWallMiddleware
+from theswarm.presentation.web.routes import auth_routes
 from theswarm.presentation.web.sse import SSEHub
 
 _HERE = Path(__file__).parent
@@ -989,9 +991,13 @@ def create_web_app(
     app.include_router(fragments.router)
     app.include_router(settings_route.router)
     app.include_router(api.router)
+    app.include_router(auth_routes.router)
 
     # Static files
     if _STATIC_DIR.is_dir():
         app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
+
+    # Issue #38 — the wall goes up last so it fronts every route above.
+    app.add_middleware(AuthWallMiddleware, base_path=base_path.rstrip("/"))
 
     return app

--- a/src/theswarm/presentation/web/auth.py
+++ b/src/theswarm/presentation/web/auth.py
@@ -1,0 +1,233 @@
+"""Session auth for the dashboard — closed by default (issue #38).
+
+Design:
+- Signed, HttpOnly session cookie (HMAC-SHA256, stdlib only).
+- Pure-ASGI middleware so SSE streaming is never buffered.
+- Fail-safe: the wall is up unless ``SWARM_AUTH_DISABLED`` is truthy —
+  losing an env var locks the app, it never silently opens it (the #31
+  lesson, inverted).
+- Two doors: the access key (``SWARM_ACCESS_KEY``) now; GitHub OAuth joins
+  it once the GitHub App exists. Both mint the same session.
+- Ops scripting: ``Authorization: Bearer <access key>`` passes the wall for
+  API calls without a cookie dance.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import secrets
+import time
+from urllib.parse import quote, urlparse
+
+from fastapi.responses import JSONResponse, RedirectResponse
+
+SESSION_COOKIE = "swarm_session"
+SESSION_TTL_SECONDS = 14 * 24 * 3600
+
+# Paths that stay open, and why (prefix match on "/"-terminated entries):
+#   /health*   — Docker healthcheck kills the container without it
+#   /static/   — css/js/fonts needed by the login page itself
+#   /login     — the door
+#   /auth/     — OAuth dance (étape 1)
+#   /webhooks/ — GitHub webhook authenticates with its own HMAC signature
+#   /d/        — deliberately public demo short-links
+_PUBLIC_EXACT = frozenset({"/health", "/login"})
+_PUBLIC_PREFIXES = ("/health/", "/static/", "/auth/", "/webhooks/", "/d/")
+
+_LOGIN_MAX_FAILURES = 5
+_LOGIN_LOCKOUT_SECONDS = 60
+
+_ephemeral_secret: str | None = None
+_login_failures: dict[str, tuple[int, float]] = {}
+
+
+def _session_secret() -> str:
+    """Env secret, or a process-ephemeral one (sessions die on restart)."""
+    configured = os.environ.get("SWARM_SESSION_SECRET", "").strip()
+    if configured:
+        return configured
+    global _ephemeral_secret
+    if _ephemeral_secret is None:
+        _ephemeral_secret = secrets.token_urlsafe(32)
+    return _ephemeral_secret
+
+
+def auth_disabled() -> bool:
+    return os.environ.get("SWARM_AUTH_DISABLED", "").strip().lower() in (
+        "1", "true", "yes",
+    )
+
+
+def access_key() -> str:
+    return os.environ.get("SWARM_ACCESS_KEY", "").strip()
+
+
+# ── Session tokens ─────────────────────────────────────────────────────
+
+
+def _sign(payload: str, secret: str) -> str:
+    digest = hmac.new(secret.encode(), payload.encode(), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+def mint_session(
+    login: str, *, secret: str | None = None,
+    ttl_seconds: int = SESSION_TTL_SECONDS,
+) -> str:
+    secret = secret or _session_secret()
+    expires = int(time.time()) + ttl_seconds
+    encoded = base64.urlsafe_b64encode(login.encode()).decode().rstrip("=")
+    payload = f"{encoded}.{expires}"
+    return f"{payload}.{_sign(payload, secret)}"
+
+
+def verify_session(token: str, *, secret: str | None = None) -> str | None:
+    secret = secret or _session_secret()
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    encoded, expires_raw, signature = parts
+    payload = f"{encoded}.{expires_raw}"
+    if not hmac.compare_digest(_sign(payload, secret), signature):
+        return None
+    try:
+        if int(expires_raw) < time.time():
+            return None
+        padding = "=" * (-len(encoded) % 4)
+        return base64.urlsafe_b64decode(encoded + padding).decode()
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+# ── Login throttle (in-memory, per process) ────────────────────────────
+
+
+def reset_login_throttle() -> None:
+    _login_failures.clear()
+
+
+def login_locked(client_ip: str) -> bool:
+    failures, locked_until = _login_failures.get(client_ip, (0, 0.0))
+    return failures >= _LOGIN_MAX_FAILURES and time.time() < locked_until
+
+
+def record_login_failure(client_ip: str) -> None:
+    failures, _ = _login_failures.get(client_ip, (0, 0.0))
+    _login_failures[client_ip] = (
+        failures + 1, time.time() + _LOGIN_LOCKOUT_SECONDS,
+    )
+
+
+def record_login_success(client_ip: str) -> None:
+    _login_failures.pop(client_ip, None)
+
+
+# ── Request helpers ────────────────────────────────────────────────────
+
+
+def _headers(scope: dict) -> dict[str, str]:
+    return {
+        k.decode("latin-1").lower(): v.decode("latin-1")
+        for k, v in scope.get("headers", [])
+    }
+
+
+def client_ip(scope_or_headers: dict, fallback: str = "?") -> str:
+    headers = (
+        _headers(scope_or_headers)
+        if "headers" in scope_or_headers and isinstance(
+            scope_or_headers.get("headers"), (list, tuple),
+        )
+        else scope_or_headers
+    )
+    forwarded = headers.get("x-forwarded-for", "")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return fallback
+
+
+def _cookie_value(headers: dict[str, str]) -> str:
+    raw = headers.get("cookie", "")
+    for part in raw.split(";"):
+        name, _, value = part.strip().partition("=")
+        if name == SESSION_COOKIE:
+            return value
+    return ""
+
+
+def _is_public(path: str) -> bool:
+    return path in _PUBLIC_EXACT or path.startswith(_PUBLIC_PREFIXES)
+
+
+def _same_origin(headers: dict[str, str]) -> bool:
+    fetch_site = headers.get("sec-fetch-site")
+    if fetch_site is not None:
+        return fetch_site in ("same-origin", "none")
+    origin = headers.get("origin")
+    if not origin:
+        return True  # non-browser client; the session/bearer check decides
+    host = headers.get("x-forwarded-host") or headers.get("host", "")
+    return urlparse(origin).netloc == host.split(",")[0].strip()
+
+
+# ── The wall ───────────────────────────────────────────────────────────
+
+
+class AuthWallMiddleware:
+    """Pure-ASGI gate: session cookie or Bearer access key, else 401/303."""
+
+    def __init__(self, app, base_path: str = "") -> None:
+        self.app = app
+        self.base = base_path.rstrip("/")
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or auth_disabled():
+            return await self.app(scope, receive, send)
+
+        path = scope["path"]
+        headers = _headers(scope)
+        method = scope.get("method", "GET")
+
+        if _is_public(path):
+            return await self.app(scope, receive, send)
+
+        # CSRF: refuse cross-site writes even with a valid session.
+        if method not in ("GET", "HEAD", "OPTIONS") and not _same_origin(headers):
+            response = JSONResponse(
+                {"detail": "Cross-site request refused"}, status_code=403,
+            )
+            return await response(scope, receive, send)
+
+        if self._is_authenticated(headers):
+            return await self.app(scope, receive, send)
+
+        login_url = f"{self.base}/login"
+        if headers.get("hx-request") == "true":
+            response = JSONResponse(
+                {"detail": "Session expired"}, status_code=401,
+                headers={"HX-Redirect": login_url},
+            )
+        elif method == "GET" and "text/html" in headers.get("accept", ""):
+            query = scope.get("query_string", b"").decode()
+            target = path + (f"?{query}" if query else "")
+            response = RedirectResponse(
+                f"{login_url}?next={quote(target, safe='')}", status_code=303,
+            )
+        else:
+            response = JSONResponse(
+                {"detail": "Authentication required"}, status_code=401,
+            )
+        await response(scope, receive, send)
+
+    def _is_authenticated(self, headers: dict[str, str]) -> bool:
+        token = _cookie_value(headers)
+        if token and verify_session(token) is not None:
+            return True
+        bearer = headers.get("authorization", "")
+        key = access_key()
+        if key and bearer.startswith("Bearer "):
+            return hmac.compare_digest(bearer.removeprefix("Bearer "), key)
+        return False

--- a/src/theswarm/presentation/web/routes/auth_routes.py
+++ b/src/theswarm/presentation/web/routes/auth_routes.py
@@ -1,0 +1,79 @@
+"""Login and logout — the only doors through the auth wall."""
+
+from __future__ import annotations
+
+import hmac
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from theswarm.presentation.web import auth
+
+router = APIRouter(tags=["auth"])
+
+
+def _safe_next(raw: str, base: str) -> str:
+    """Only app-relative paths — never an absolute URL (open redirect)."""
+    if raw.startswith("/") and not raw.startswith("//"):
+        return raw
+    return f"{base}/" if base else "/"
+
+
+def _set_session_cookie(response: RedirectResponse, request: Request) -> None:
+    base = request.app.state.base_path
+    forwarded_proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+    response.set_cookie(
+        auth.SESSION_COOKIE,
+        auth.mint_session("owner"),
+        max_age=auth.SESSION_TTL_SECONDS,
+        path=f"{base}/" if base else "/",
+        httponly=True,
+        samesite="lax",
+        secure=forwarded_proto == "https",
+    )
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request, next: str = "") -> HTMLResponse:
+    templates = request.app.state.templates
+    return templates.TemplateResponse("login.html", {"next": next, "error": ""})
+
+
+@router.post("/login")
+async def login_submit(
+    request: Request,
+    access_key: str = Form(default=""),
+    next: str = Form(default=""),
+):
+    templates = request.app.state.templates
+    base = request.app.state.base_path
+    ip = auth.client_ip(dict(request.headers), fallback=request.client.host if request.client else "?")
+
+    if auth.login_locked(ip):
+        return templates.TemplateResponse(
+            "login.html",
+            {"next": next, "error": "Too many attempts — wait a minute."},
+            status_code=429,
+        )
+
+    expected = auth.access_key()
+    if not expected or not hmac.compare_digest(access_key, expected):
+        auth.record_login_failure(ip)
+        return templates.TemplateResponse(
+            "login.html",
+            {"next": next, "error": "That key doesn't match."},
+            status_code=401,
+        )
+
+    auth.record_login_success(ip)
+    response = RedirectResponse(_safe_next(next, base), status_code=303)
+    _set_session_cookie(response, request)
+    return response
+
+
+@router.post("/logout")
+async def logout(request: Request) -> RedirectResponse:
+    base = request.app.state.base_path
+    response = RedirectResponse(f"{base}/login", status_code=303)
+    response.delete_cookie(auth.SESSION_COOKIE, path=f"{base}/" if base else "/")
+    return response

--- a/src/theswarm/presentation/web/templates/login.html
+++ b/src/theswarm/presentation/web/templates/login.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TheSwarm — Sign in</title>
+  <style>
+    :root {
+      --paper: #FAF9F6; --ink: #1C1E21; --soft: #6B7178;
+      --rule: #DDDCD6; --accent: #B8860B; --error: #A8452B;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; min-height: 100vh; display: grid; place-items: center;
+      background: var(--paper); color: var(--ink);
+      font: 16px/1.5 system-ui, -apple-system, sans-serif;
+    }
+    main { width: min(22rem, 90vw); display: flex; flex-direction: column; gap: 1.5rem; }
+    h1 { font-size: 1.4rem; margin: 0; letter-spacing: -0.01em; }
+    h1 span { color: var(--accent); }
+    p.hint { margin: 0; color: var(--soft); font-size: 0.9rem; }
+    form { display: flex; flex-direction: column; gap: 0.75rem; }
+    input[type=password] {
+      font: inherit; padding: 0.65rem 0.8rem; border: 1px solid var(--rule);
+      border-radius: 6px; background: #fff; color: var(--ink); width: 100%;
+    }
+    input[type=password]:focus { outline: 2px solid var(--accent); outline-offset: 1px; border-color: transparent; }
+    button {
+      font: inherit; font-weight: 600; padding: 0.65rem; border: none;
+      border-radius: 6px; background: var(--ink); color: var(--paper); cursor: pointer;
+    }
+    button:hover { background: #000; }
+    button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .error { color: var(--error); font-size: 0.9rem; margin: 0; }
+    @media (prefers-color-scheme: dark) {
+      :root { --paper: #15171A; --ink: #E9EAE7; --soft: #9AA1A8; --rule: #33383E; }
+      input[type=password] { background: #1E2126; }
+      button { background: var(--ink); color: var(--paper); }
+      button:hover { background: #fff; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>The<span>Swarm</span></h1>
+    <p class="hint">This instance is private. Enter the access key from the server's <code>.env</code>.</p>
+    {% if error %}<p class="error">{{ error }}</p>{% endif %}
+    <form method="post" action="{{ base }}/login">
+      <input type="hidden" name="next" value="{{ next }}">
+      <input type="password" name="access_key" placeholder="Access key"
+             autocomplete="current-password" autofocus required>
+      <button type="submit">Sign in</button>
+    </form>
+  </main>
+</body>
+</html>

--- a/tests/application/test_startup_validator.py
+++ b/tests/application/test_startup_validator.py
@@ -22,6 +22,10 @@ class TestValidate:
         monkeypatch.setenv("EXTERNAL_URL", "https://swarm.example.com")
         monkeypatch.setenv("MATTERMOST_BOT_TOKEN", "mm-test")
         monkeypatch.setenv("SWARM_VAULT_MASTER_KEY", "fake-fernet-key")
+        # A fully-configured deployment runs with the auth wall up (issue #38)
+        monkeypatch.setenv("SWARM_AUTH_DISABLED", "")
+        monkeypatch.setenv("SWARM_ACCESS_KEY", "fake-access-key")
+        monkeypatch.setenv("SWARM_SESSION_SECRET", "fake-session-secret")
         result = validator.validate()
         assert result.ok
         assert len(result.errors) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,19 @@ def _default_claude_backend_for_tests(monkeypatch):
         monkeypatch.setenv("SWARM_CLAUDE_BACKEND", "api")
 
 
+@pytest.fixture(autouse=True)
+def _auth_open_for_tests(monkeypatch):
+    """Keep the auth wall (issue #38) down for the suite.
+
+    Production fails CLOSED: the wall is up unless SWARM_AUTH_DISABLED is
+    truthy. The 86 web-test modules build the app directly and would all
+    need a login dance otherwise. Tests that exercise the wall re-enable it
+    with ``monkeypatch.setenv("SWARM_AUTH_DISABLED", "")``.
+    """
+    if "SWARM_AUTH_DISABLED" not in os.environ:
+        monkeypatch.setenv("SWARM_AUTH_DISABLED", "1")
+
+
 @pytest.fixture()
 def mock_settings():
     """Return a SwarmSettings-like object without importing pydantic models."""

--- a/tests/e2e/test_dashboard_e2e.py
+++ b/tests/e2e/test_dashboard_e2e.py
@@ -30,6 +30,8 @@ SEEDED_VIDEO_REL_PATH = "e2e-seed-cycle-video/video/demo.webm"
 
 def _run_server(db_path: str, artifact_dir: str = ""):
     """Start the TheSwarm server in a subprocess using an isolated DB."""
+    import os
+    os.environ.setdefault("SWARM_AUTH_DISABLED", "1")
     import asyncio
     from theswarm.presentation.web.server import start_server
     asyncio.run(start_server(

--- a/tests/presentation/test_auth_wall.py
+++ b/tests/presentation/test_auth_wall.py
@@ -1,0 +1,225 @@
+"""The dashboard is closed by default; only monitoring stays open.
+
+Issue #38: the production app answered anonymous requests on every route,
+including the ones that spend money (POST /api/cycle) and write to GitHub.
+The wall is fail-safe: enforced unless SWARM_AUTH_DISABLED is truthy, which
+only tests and local dev set (tests/conftest.py does it suite-wide).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from theswarm.application.events.bus import EventBus
+from theswarm.infrastructure.persistence.sqlite_repos import (
+    SQLiteCycleRepository,
+    SQLiteProjectRepository,
+    init_db,
+)
+from theswarm.presentation.web import auth as auth_mod
+from theswarm.presentation.web.app import create_web_app
+from theswarm.presentation.web.auth import mint_session, verify_session
+from theswarm.presentation.web.sse import SSEHub
+
+SECRET = "test-session-secret"
+KEY = "test-access-key"
+
+
+@pytest.fixture(autouse=True)
+def _wall_enabled(monkeypatch):
+    """Turn the wall ON for this module (the suite-wide default is OFF)."""
+    monkeypatch.setenv("SWARM_AUTH_DISABLED", "")
+    monkeypatch.setenv("SWARM_SESSION_SECRET", SECRET)
+    monkeypatch.setenv("SWARM_ACCESS_KEY", KEY)
+    auth_mod.reset_login_throttle()
+
+
+@pytest.fixture()
+async def client(tmp_path):
+    conn = await init_db(str(tmp_path / "test.db"))
+    app = create_web_app(
+        SQLiteProjectRepository(conn), SQLiteCycleRepository(conn),
+        EventBus(), SSEHub(),
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    await conn.close()
+
+
+async def _login(client) -> None:
+    r = await client.post("/login", data={"access_key": KEY})
+    assert r.status_code == 303
+
+
+# ── Session tokens ─────────────────────────────────────────────────────
+
+
+def test_session_roundtrip():
+    token = mint_session("jrechet", secret=SECRET, ttl_seconds=60)
+    assert verify_session(token, secret=SECRET) == "jrechet"
+
+
+def test_expired_session_is_rejected():
+    token = mint_session("jrechet", secret=SECRET, ttl_seconds=-1)
+    assert verify_session(token, secret=SECRET) is None
+
+
+def test_tampered_session_is_rejected():
+    token = mint_session("jrechet", secret=SECRET, ttl_seconds=60)
+    assert verify_session(token + "x", secret=SECRET) is None
+    assert verify_session("garbage", secret=SECRET) is None
+    assert verify_session(token, secret="other-secret") is None
+
+
+# ── Anonymous requests hit the wall ────────────────────────────────────
+
+
+async def test_anonymous_html_page_redirects_to_login(client):
+    r = await client.get("/projects/", headers={"Accept": "text/html"})
+    assert r.status_code == 303
+    assert r.headers["location"].endswith("/login?next=%2Fprojects%2F")
+
+
+async def test_anonymous_api_gets_401(client):
+    r = await client.get("/api/dashboard")
+    assert r.status_code == 401
+
+
+async def test_anonymous_cannot_start_a_cycle(client):
+    """The exact call reproduced from outside in issue #38."""
+    r = await client.post("/api/cycle", json={"repo": "a/b"})
+    assert r.status_code == 401
+
+
+async def test_anonymous_htmx_fragment_gets_hx_redirect(client):
+    r = await client.get("/fragments/stats", headers={"HX-Request": "true"})
+    assert r.status_code == 401
+    assert r.headers["HX-Redirect"].endswith("/login")
+
+
+# ── What stays open, and why ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path", [
+    "/health",            # Docker healthcheck — the container dies without it
+    "/health/ready",      # readiness probe
+])
+async def test_monitoring_stays_open(client, path):
+    r = await client.get(path)
+    assert r.status_code == 200
+
+
+async def test_login_page_is_reachable(client):
+    r = await client.get("/login")
+    assert r.status_code == 200
+    assert "access_key" in r.text
+
+
+async def test_webhook_keeps_its_own_hmac_auth(client):
+    """The GitHub webhook authenticates via X-Hub-Signature-256, not session."""
+    r = await client.post("/webhooks/github", json={})
+    assert r.status_code != 303  # not bounced to the login page
+    assert r.status_code in (401, 501)  # its own logic answers
+
+
+async def test_public_demo_short_links_stay_open(client):
+    r = await client.get("/d/abc123")
+    assert r.status_code in (200, 404)  # not walled, just possibly absent
+
+
+# ── Logging in ─────────────────────────────────────────────────────────
+
+
+async def test_wrong_key_is_rejected_without_a_cookie(client):
+    r = await client.post("/login", data={"access_key": "wrong"})
+    assert r.status_code == 401
+    assert "set-cookie" not in r.headers
+
+
+async def test_right_key_opens_the_dashboard(client):
+    await _login(client)
+    r = await client.get("/projects/")
+    assert r.status_code == 200
+
+
+async def test_login_redirects_to_next_path(client):
+    r = await client.post(
+        "/login", data={"access_key": KEY, "next": "/cycles/"},
+    )
+    assert r.status_code == 303
+    assert r.headers["location"] == "/cycles/"
+
+
+async def test_next_cannot_be_an_absolute_url(client):
+    """Open-redirect guard: next must be an app-relative path."""
+    r = await client.post(
+        "/login", data={"access_key": KEY, "next": "https://evil.example"},
+    )
+    assert r.status_code == 303
+    assert "evil.example" not in r.headers["location"]
+
+
+async def test_logout_closes_the_session(client):
+    await _login(client)
+    r = await client.post("/logout")
+    assert r.status_code == 303
+    r = await client.get("/projects/", headers={"Accept": "text/html"})
+    assert r.status_code == 303  # walled again
+
+
+async def test_bearer_access_key_allows_api_scripting(client):
+    """Ops scripts can call the API with the access key as a Bearer token."""
+    r = await client.get(
+        "/api/dashboard", headers={"Authorization": f"Bearer {KEY}"},
+    )
+    assert r.status_code == 200
+
+
+async def test_login_throttles_after_repeated_failures(client):
+    for _ in range(5):
+        r = await client.post("/login", data={"access_key": "wrong"})
+        assert r.status_code == 401
+    r = await client.post("/login", data={"access_key": KEY})
+    assert r.status_code == 429  # even the right key waits out the lockout
+
+
+# ── CSRF: cross-site writes are refused ────────────────────────────────
+
+
+async def test_cross_site_post_is_refused(client):
+    await _login(client)
+    r = await client.post(
+        "/api/cycle", json={"repo": "a/b"},
+        headers={"Origin": "https://evil.example"},
+    )
+    assert r.status_code == 403
+
+
+async def test_same_origin_post_passes_csrf(client):
+    await _login(client)
+    r = await client.post(
+        "/logout", headers={"Origin": "http://test"},
+    )
+    assert r.status_code == 303
+
+
+# ── The kill switch is explicit, never implicit ────────────────────────
+
+
+async def test_no_access_key_still_walls_but_cannot_login(client, monkeypatch):
+    """Losing the env vars must fail CLOSED, not open (the #31 lesson)."""
+    monkeypatch.setenv("SWARM_ACCESS_KEY", "")
+    r = await client.get("/projects/", headers={"Accept": "text/html"})
+    assert r.status_code == 303  # still walled
+    r = await client.post("/login", data={"access_key": ""})
+    assert r.status_code == 401  # empty key never matches
+
+
+async def test_disabled_flag_opens_everything(client, monkeypatch):
+    monkeypatch.setenv("SWARM_AUTH_DISABLED", "1")
+    r = await client.get("/projects/")
+    assert r.status_code == 200


### PR DESCRIPTION
Closes #38.

Anonymous requests could read project config, start cycles (verified from outside: POST /api/cycle → 200) and make the Dev agent push code. This PR puts a signed-session wall in front of everything.

## Design
- **Fail-safe closed**: enforced unless `SWARM_AUTH_DISABLED` is truthy (tests/local dev only, set suite-wide in `tests/conftest.py`). Losing an env var locks the app; it never silently opens it.
- Pure-ASGI middleware (SSE streams untouched), signed HttpOnly cookie, stdlib HMAC only — no new dependency.
- `/login` + access key (`SWARM_ACCESS_KEY`), throttled 5 tries/60 s; `Authorization: Bearer <key>` passes `/api/*` for ops scripts.
- Stays open by design: `/health*` (Docker healthcheck), `/static`, `/login`, `/auth/*` (OAuth, étape 1), `/webhooks/*` (own HMAC), `/d/*` (public demo links).
- CSRF: cross-site writes 403 via `Sec-Fetch-Site`/`Origin`.
- GitHub OAuth login lands with the GitHub App (étape 1 of docs/plans/2026-09-v2-one-flow.md); the access key stays as break-glass.

## Deploy chain
Repo secrets `SWARM_ACCESS_KEY` / `SWARM_SESSION_SECRET` (already set) → `write-env` action → `.env` → container. The key is on the server at `~/swarm-access-key.txt`.

## Tests
23 new (`tests/presentation/test_auth_wall.py`): wall, doors, throttle, CSRF, open paths, fail-closed. Full suite 2318 green; e2e smoke walk green.