### PR TITLE
feat(web): the theater — watch the four agents build

### DIFF
--- a/src/theswarm/application/services/pinned_issue.py
+++ b/src/theswarm/application/services/pinned_issue.py
@@ -1,0 +1,49 @@
+"""What a targeted cycle is building: the pinned issue and its breakdown.
+
+Shared by the V1 cycle fragment and the V2 theater. The TechLead breakdown
+creates sub-issues carrying ``Parent: #N``; reading them back answers
+"the feature was split into X tasks, here is where each one stands".
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PinnedIssue:
+    issue: dict | None = None
+    children: tuple[dict, ...] = field(default_factory=tuple)
+    done: int = 0
+    error: str = ""
+
+
+async def load_pinned_issue(repo: str, issue_number: int | None) -> PinnedIssue:
+    if not repo or issue_number is None:
+        return PinnedIssue()
+    try:
+        from theswarm.tools.github import GitHubClient, issue_status
+
+        client = GitHubClient(repo)
+        issue = await client.get_issue(issue_number)
+        if issue is None:
+            return PinnedIssue()
+        marker = f"Parent: #{issue_number}"
+        everything = await client.get_issues(state="all")
+        children = tuple(
+            {
+                "number": child["number"],
+                "title": child["title"],
+                "status": issue_status(child),
+            }
+            for child in everything
+            if marker in (child.get("body") or "")
+        )
+        done = sum(1 for c in children if c["status"] == "review")
+        return PinnedIssue(issue=issue, children=children, done=done)
+    except Exception as exc:  # noqa: BLE001 — degrade the panel, not the page
+        log.exception("Failed to read issue %s on %s", issue_number, repo)
+        return PinnedIssue(error=str(exc)[:200])

--- a/src/theswarm/presentation/web/routes/fragments.py
+++ b/src/theswarm/presentation/web/routes/fragments.py
@@ -150,32 +150,13 @@ async def cycle_issue_fragment(request: Request, cycle_id: str) -> HTMLResponse:
         )
 
     context["repo"] = record.repo
-    try:
-        from theswarm.tools.github import GitHubClient
+    from theswarm.application.services.pinned_issue import load_pinned_issue
 
-        client = GitHubClient(record.repo)
-        issue = await client.get_issue(record.issue_number)
-        context["issue"] = issue
-        if issue is not None:
-            from theswarm.tools.github import issue_status
-
-            marker = f"Parent: #{record.issue_number}"
-            everything = await client.get_issues(state="all")
-            children = [
-                {
-                    "number": child["number"],
-                    "title": child["title"],
-                    "status": issue_status(child),
-                }
-                for child in everything
-                if marker in (child.get("body") or "")
-            ]
-            context["children"] = children
-            context["done"] = sum(1 for c in children if c["status"] == "review")
-    except Exception as exc:  # noqa: BLE001 — degrade the panel, not the page
-        log.exception("Failed to read issue %s for cycle %s",
-                      record.issue_number, cycle_id)
-        context["error"] = str(exc)[:200]
+    pinned = await load_pinned_issue(record.repo, record.issue_number)
+    context["issue"] = pinned.issue
+    context["children"] = list(pinned.children)
+    context["done"] = pinned.done
+    context["error"] = pinned.error
 
     return request.app.state.templates.TemplateResponse(
         "partials/_cycle_issue.html", context,

--- a/src/theswarm/presentation/web/routes/v2.py
+++ b/src/theswarm/presentation/web/routes/v2.py
@@ -213,4 +213,145 @@ async def play(
     log.info("V2: Play #%d on %s → cycle %s", issue_number, full_name, record.id)
 
     base = state.base_path
-    return RedirectResponse(f"{base}/cycles/{record.id}", status_code=303)
+    return RedirectResponse(f"{base}/c/{record.id}", status_code=303)
+
+
+# ── The theater: watch the swarm build ─────────────────────────────────
+
+_STATIONS = (
+    ("po", "PO", "Product Owner"),
+    ("techlead", "TL", "Tech Lead"),
+    ("dev", "DEV", "Developer"),
+    ("qa", "QA", "QA"),
+)
+_ROLE_ALIASES = {
+    "po": "po", "product_owner": "po", "productowner": "po",
+    "techlead": "techlead", "tech_lead": "techlead", "tl": "techlead",
+    "dev": "dev", "developer": "dev",
+    "qa": "qa", "tester": "qa",
+}
+_FEED_LIMIT = 250
+
+
+def _normalize_role(raw: str) -> str | None:
+    return _ROLE_ALIASES.get(raw.strip().lower().replace("-", "_"))
+
+
+def _stations(record, progress: list[dict]) -> list[dict]:
+    """Map live progress onto the four fixed stations.
+
+    ``progress`` is most-recent-first; the freshest role is the active
+    station, everything before it on the rail is done, everything after
+    waits. On failure the active station carries the cross.
+    """
+    latest: dict[str, str] = {}
+    active: str | None = None
+    for row in progress:
+        role = _normalize_role(str(row.get("role", "")))
+        if role is None:
+            continue
+        if role not in latest:
+            latest[role] = str(row.get("message", ""))
+        if active is None:
+            active = role
+
+    keys = [key for key, _, _ in _STATIONS]
+    status = record.status.value
+    if active is None:
+        active_index = 0 if status == "running" else -1
+    else:
+        active_index = keys.index(active)
+
+    stations: list[dict] = []
+    for index, (key, glyph, name) in enumerate(_STATIONS):
+        if status == "completed":
+            state = "done"
+        elif status in ("failed", "cancelled"):
+            if active_index == -1 or index > active_index:
+                state = "waiting"
+            elif index == active_index:
+                state = "failed"
+            else:
+                state = "done"
+        elif status in ("running", "queued") and active_index >= 0:
+            if index < active_index:
+                state = "done"
+            elif index == active_index:
+                state = "active"
+            else:
+                state = "waiting"
+        else:
+            state = "waiting"
+        stations.append({
+            "key": key, "glyph": glyph, "name": name,
+            "state": state, "message": latest.get(key, ""),
+        })
+    return stations
+
+
+async def _stage_context(request: Request, record) -> dict:
+    from theswarm.application.services.pinned_issue import load_pinned_issue
+    from theswarm.application.services.progress_bridge import get_live_progress
+
+    progress = get_live_progress(record.id)
+
+    feed: list[dict] = []
+    thoughts_query = getattr(request.app.state, "get_agent_thoughts_query", None)
+    if thoughts_query is not None:
+        try:
+            entries = await thoughts_query.execute(record.id)
+        except Exception:  # noqa: BLE001 — the feed degrades, the page stays
+            log.exception("V2: reading thoughts for %s failed", record.id)
+            entries = []
+        glyphs = {key: glyph for key, glyph, _ in _STATIONS}
+        for entry in reversed(entries[-_FEED_LIMIT:]):
+            role = _normalize_role(entry.agent) or ""
+            feed.append({
+                "time": entry.occurred_at.strftime("%H:%M:%S"),
+                "agent": role or entry.agent,
+                "glyph": glyphs.get(role, entry.agent[:3].upper()),
+                "kind": entry.kind,
+                "text": entry.text,
+            })
+
+    pinned = await load_pinned_issue(record.repo, record.issue_number)
+    return {
+        "record": record,
+        "stations": _stations(record, progress),
+        "pinned": pinned,
+        "feed": feed,
+    }
+
+
+def _tracker_record(cycle_id: str):
+    from theswarm.api import get_cycle_tracker
+
+    return get_cycle_tracker().get(cycle_id)
+
+
+@router.get("/c/{cycle_id}", response_class=HTMLResponse)
+async def theater(request: Request, cycle_id: str):
+    state = request.app.state
+    record = _tracker_record(cycle_id)
+    if record is None:
+        # Historical cycle (tracker is in-memory): the V1 detail page reads
+        # the database and stays the archive view.
+        cycle = await state.get_cycle_status_query.execute(cycle_id)
+        if cycle is not None:
+            return RedirectResponse(
+                f"{state.base_path}/cycles/{cycle_id}", status_code=303,
+            )
+        return HTMLResponse("Cycle not found", status_code=404)
+    context = await _stage_context(request, record)
+    return state.templates.TemplateResponse("v2/theater.html", context)
+
+
+@router.get("/c/{cycle_id}/stage", response_class=HTMLResponse)
+async def theater_stage(request: Request, cycle_id: str):
+    record = _tracker_record(cycle_id)
+    if record is None:
+        return HTMLResponse("", status_code=404)
+    context = await _stage_context(request, record)
+    return request.app.state.templates.TemplateResponse(
+        "v2/_stage.html", context,
+    )

--- a/src/theswarm/presentation/web/static/v2/app.css
+++ b/src/theswarm/presentation/web/static/v2/app.css
@@ -16,6 +16,8 @@
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --tracking-tight: -0.025em;
+    --tracking-normal: 0em;
+    --leading-tight: 1.25;
     --leading-snug: 1.375;
     --leading-relaxed: 1.625;
     --radius-sm: 0.25rem;
@@ -241,11 +243,26 @@
   .mt-2 {
     margin-top: calc(var(--spacing) * 2);
   }
+  .mt-3 {
+    margin-top: calc(var(--spacing) * 3);
+  }
+  .mt-6 {
+    margin-top: calc(var(--spacing) * 6);
+  }
+  .mt-7 {
+    margin-top: calc(var(--spacing) * 7);
+  }
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
   }
   .ml-auto {
     margin-left: auto;
+  }
+  .line-clamp-2 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
   }
   .block {
     display: block;
@@ -277,6 +294,12 @@
   .h-14 {
     height: calc(var(--spacing) * 14);
   }
+  .max-h-\[26rem\] {
+    max-height: 26rem;
+  }
+  .min-h-\[2\.4em\] {
+    min-height: 2.4em;
+  }
   .min-h-screen {
     min-height: 100vh;
   }
@@ -286,8 +309,14 @@
   .w-2 {
     width: calc(var(--spacing) * 2);
   }
+  .w-9 {
+    width: calc(var(--spacing) * 9);
+  }
   .w-12 {
     width: calc(var(--spacing) * 12);
+  }
+  .w-14 {
+    width: calc(var(--spacing) * 14);
   }
   .w-full {
     width: 100%;
@@ -328,6 +357,9 @@
   .resize-y {
     resize: vertical;
   }
+  .grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
   .flex-col {
     flex-direction: column;
   }
@@ -343,6 +375,9 @@
   .items-end {
     align-items: flex-end;
   }
+  .items-start {
+    align-items: flex-start;
+  }
   .justify-between {
     justify-content: space-between;
   }
@@ -351,6 +386,9 @@
   }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
+  }
+  .gap-2\.5 {
+    gap: calc(var(--spacing) * 2.5);
   }
   .gap-3 {
     gap: calc(var(--spacing) * 3);
@@ -377,6 +415,12 @@
   :where(.divide-rule > :not(:last-child)) {
     border-color: var(--rule);
   }
+  :where(.divide-rule\/60 > :not(:last-child)) {
+    border-color: var(--rule);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--rule) 60%, transparent);
+    }
+  }
   .self-start {
     align-self: flex-start;
   }
@@ -384,6 +428,9 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  .overflow-y-auto {
+    overflow-y: auto;
   }
   .rounded {
     border-radius: 0.25rem;
@@ -413,19 +460,43 @@
     --tw-border-style: dashed;
     border-style: dashed;
   }
+  .border-honey {
+    border-color: var(--honey);
+  }
   .border-honey\/40 {
     border-color: var(--honey);
     @supports (color: color-mix(in lab, red, red)) {
       border-color: color-mix(in oklab, var(--honey) 40%, transparent);
     }
   }
+  .border-honey\/50 {
+    border-color: var(--honey);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--honey) 50%, transparent);
+    }
+  }
+  .border-moss\/50 {
+    border-color: var(--moss);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--moss) 50%, transparent);
+    }
+  }
   .border-rule {
     border-color: var(--rule);
+  }
+  .border-rust {
+    border-color: var(--rust);
   }
   .border-rust\/30 {
     border-color: var(--rust);
     @supports (color: color-mix(in lab, red, red)) {
       border-color: color-mix(in oklab, var(--rust) 30%, transparent);
+    }
+  }
+  .border-rust\/50 {
+    border-color: var(--rust);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--rust) 50%, transparent);
     }
   }
   .bg-honey {
@@ -434,8 +505,20 @@
   .bg-honey-wash {
     background-color: var(--honey-wash);
   }
+  .bg-honey-wash\/50 {
+    background-color: var(--honey-wash);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--honey-wash) 50%, transparent);
+    }
+  }
   .bg-ink {
     background-color: var(--ink);
+  }
+  .bg-moss {
+    background-color: var(--moss);
+  }
+  .bg-moss-wash {
+    background-color: var(--moss-wash);
   }
   .bg-panel {
     background-color: var(--panel);
@@ -443,11 +526,23 @@
   .bg-paper {
     background-color: var(--paper);
   }
+  .bg-rule {
+    background-color: var(--rule);
+  }
   .bg-rust-wash {
     background-color: var(--rust-wash);
   }
+  .bg-rust-wash\/40 {
+    background-color: var(--rust-wash);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--rust-wash) 40%, transparent);
+    }
+  }
   .bg-transparent {
     background-color: transparent;
+  }
+  .p-4 {
+    padding: calc(var(--spacing) * 4);
   }
   .p-5 {
     padding: calc(var(--spacing) * 5);
@@ -473,6 +568,9 @@
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
   }
+  .py-1 {
+    padding-block: var(--spacing);
+  }
   .py-1\.5 {
     padding-block: calc(var(--spacing) * 1.5);
   }
@@ -497,8 +595,17 @@
   .py-10 {
     padding-block: calc(var(--spacing) * 10);
   }
+  .pt-0\.5 {
+    padding-top: calc(var(--spacing) * 0.5);
+  }
+  .pt-1 {
+    padding-top: var(--spacing);
+  }
   .text-center {
     text-align: center;
+  }
+  .text-left {
+    text-align: left;
   }
   .font-mono {
     font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
@@ -517,6 +624,12 @@
   .text-\[11px\] {
     font-size: 11px;
   }
+  .text-\[12\.5px\] {
+    font-size: 12.5px;
+  }
+  .text-\[13\.5px\] {
+    font-size: 13.5px;
+  }
   .text-\[13px\] {
     font-size: 13px;
   }
@@ -525,6 +638,9 @@
   }
   .text-\[17px\] {
     font-size: 17px;
+  }
+  .text-\[22px\] {
+    font-size: 22px;
   }
   .text-\[26px\] {
     font-size: 26px;
@@ -536,6 +652,10 @@
   .leading-snug {
     --tw-leading: var(--leading-snug);
     line-height: var(--leading-snug);
+  }
+  .leading-tight {
+    --tw-leading: var(--leading-tight);
+    line-height: var(--leading-tight);
   }
   .font-medium {
     --tw-font-weight: var(--font-weight-medium);
@@ -549,9 +669,21 @@
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
   }
+  .tracking-\[0\.1em\] {
+    --tw-tracking: 0.1em;
+    letter-spacing: 0.1em;
+  }
+  .tracking-\[0\.12em\] {
+    --tw-tracking: 0.12em;
+    letter-spacing: 0.12em;
+  }
   .tracking-\[0\.14em\] {
     --tw-tracking: 0.14em;
     letter-spacing: 0.14em;
+  }
+  .tracking-normal {
+    --tw-tracking: var(--tracking-normal);
+    letter-spacing: var(--tracking-normal);
   }
   .tracking-tight {
     --tw-tracking: var(--tracking-tight);
@@ -559,6 +691,9 @@
   }
   .text-balance {
     text-wrap: balance;
+  }
+  .break-words {
+    overflow-wrap: break-word;
   }
   .text-faint {
     color: var(--faint);
@@ -572,6 +707,9 @@
   .text-ink {
     color: var(--ink);
   }
+  .text-moss {
+    color: var(--moss);
+  }
   .text-paper {
     color: var(--paper);
   }
@@ -581,6 +719,9 @@
   .text-soft {
     color: var(--soft);
   }
+  .normal-case {
+    text-transform: none;
+  }
   .uppercase {
     text-transform: uppercase;
   }
@@ -588,9 +729,18 @@
     --tw-ordinal: ordinal;
     font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
   }
+  .line-through {
+    text-decoration-line: line-through;
+  }
+  .decoration-rule {
+    text-decoration-color: var(--rule);
+  }
   .antialiased {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+  .opacity-55 {
+    opacity: 55%;
   }
   .shadow {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
@@ -599,6 +749,13 @@
   .ring {
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring-2 {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring-honey {
+    --tw-ring-color: var(--honey);
   }
   .outline {
     outline-style: var(--tw-outline-style);
@@ -685,6 +842,11 @@
   }
   .focus-visible\:outline-honey:focus-visible {
     outline-color: var(--honey);
+  }
+  @media (width >= 48rem) {
+    .md\:grid-cols-4 {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
   }
 }
 @font-face {

--- a/src/theswarm/presentation/web/templates/v2/_stage.html
+++ b/src/theswarm/presentation/web/templates/v2/_stage.html
@@ -1,0 +1,95 @@
+{# The stage: everything that moves while a cycle runs. Re-rendered whole
+   by the page's poll loop; data-status lets the client stop polling. #}
+<div id="stage-inner" data-status="{{ record.status.value }}">
+
+  {# ── The agent rail ─────────────────────────────────────────────── #}
+  <ol class="grid grid-cols-2 md:grid-cols-4 gap-3" data-testid="agent-rail">
+    {% for s in stations %}
+    <li>
+      <button type="button" data-role="{{ s.key }}" data-state="{{ s.state }}"
+        class="station w-full text-left border rounded-lg p-4 flex flex-col gap-2 transition-colors cursor-pointer focus-visible:outline-2 focus-visible:outline-honey
+        {% if s.state == 'active' %}border-honey bg-honey-wash/50
+        {% elif s.state == 'failed' %}border-rust bg-rust-wash/40
+        {% elif s.state == 'done' %}border-rule bg-panel
+        {% else %}border-rule bg-panel opacity-55{% endif %}">
+        <span class="flex items-center justify-between">
+          <span class="font-mono text-[11px] tracking-[0.12em] {% if s.state == 'active' %}text-honey-deep{% else %}text-faint{% endif %}">{{ s.glyph }}</span>
+          {% if s.state == 'active' %}
+          <span class="w-2 h-2 rounded-full bg-honey swarm-working" aria-hidden="true"></span>
+          {% elif s.state == 'done' %}
+          <span class="text-moss text-[13px]" aria-label="done">✓</span>
+          {% elif s.state == 'failed' %}
+          <span class="text-rust text-[13px]" aria-label="failed">✕</span>
+          {% endif %}
+        </span>
+        <span class="text-[15px] font-semibold leading-tight">{{ s.name }}</span>
+        <span class="text-[12.5px] text-soft leading-snug line-clamp-2 min-h-[2.4em]">
+          {%- if s.message %}{{ s.message }}{% elif s.state == 'waiting' %}Waiting…{% elif s.state == 'done' %}Done.{% endif -%}
+        </span>
+      </button>
+    </li>
+    {% endfor %}
+  </ol>
+
+  {# ── What is being built ────────────────────────────────────────── #}
+  {% if pinned.issue %}
+  <section class="mt-7 border border-rule rounded-lg bg-panel p-5" aria-labelledby="stage-issue" data-testid="pinned-issue">
+    <div class="flex items-baseline justify-between gap-4 flex-wrap">
+      <h2 id="stage-issue" class="text-[15px] font-semibold">
+        <span class="font-mono text-faint font-normal">#{{ pinned.issue.number }}</span>
+        {{ pinned.issue.title }}
+      </h2>
+      {% if pinned.children %}
+      <span class="font-mono text-[11px] text-faint">{{ pinned.done }}/{{ pinned.children | length }} done</span>
+      {% endif %}
+    </div>
+    {% if pinned.children %}
+    <ul class="mt-3 flex flex-col gap-1.5">
+      {% for child in pinned.children %}
+      <li class="flex items-center gap-2.5 text-[13.5px]">
+        {% if child.status == 'review' %}
+        <span class="w-1.5 h-1.5 rounded-full bg-moss shrink-0" aria-hidden="true"></span>
+        <span class="text-soft line-through decoration-rule">{{ child.title }}</span>
+        {% elif child.status == 'in-progress' %}
+        <span class="w-1.5 h-1.5 rounded-full bg-honey swarm-working shrink-0" aria-hidden="true"></span>
+        <span>{{ child.title }}</span>
+        {% else %}
+        <span class="w-1.5 h-1.5 rounded-full bg-rule shrink-0" aria-hidden="true"></span>
+        <span class="text-soft">{{ child.title }}</span>
+        {% endif %}
+        <span class="font-mono text-[11px] text-faint ml-auto shrink-0">#{{ child.number }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    {% elif record.status.value == 'running' %}
+    <p class="mt-2 text-[13px] text-faint">The TechLead hasn't split it yet.</p>
+    {% endif %}
+  </section>
+  {% endif %}
+
+  {# ── Activity feed ──────────────────────────────────────────────── #}
+  <section class="mt-7" aria-labelledby="stage-feed">
+    <h2 id="stage-feed" class="font-mono text-[11px] uppercase tracking-[0.14em] text-faint mb-2">
+      Activity <span id="feed-filter-note" class="normal-case tracking-normal"></span>
+    </h2>
+    {% if feed %}
+    <ol class="border-y border-rule divide-y divide-rule/60 max-h-[26rem] overflow-y-auto" data-testid="feed">
+      {% for e in feed %}
+      <li class="feed-entry flex gap-3 py-2 px-1 text-[13px] leading-relaxed" data-agent="{{ e.agent }}">
+        <span class="font-mono text-[11px] text-faint shrink-0 pt-0.5 w-14">{{ e.time }}</span>
+        <span class="font-mono text-[11px] shrink-0 pt-0.5 w-9 {% if e.kind == 'step' %}text-faint{% else %}text-honey-deep{% endif %}">{{ e.glyph }}</span>
+        <span class="min-w-0 {% if e.kind == 'step' %}text-soft{% endif %}">{{ e.text }}</span>
+      </li>
+      {% endfor %}
+    </ol>
+    {% else %}
+    <p class="text-[13px] text-faint border border-dashed border-rule rounded-lg py-5 text-center">
+      Nothing yet — the swarm announces itself here.</p>
+    {% endif %}
+  </section>
+
+  {% if record.error %}
+  <p class="mt-6 text-[13px] text-rust border border-rust/30 bg-rust-wash rounded-lg px-4 py-3 font-mono break-words">
+    {{ record.error }}</p>
+  {% endif %}
+</div>

--- a/src/theswarm/presentation/web/templates/v2/repo.html
+++ b/src/theswarm/presentation/web/templates/v2/repo.html
@@ -14,7 +14,7 @@
   </div>
 
   {% if running_cycle %}
-  <a href="{{ base }}/cycles/{{ running_cycle.id }}" data-testid="running-banner"
+  <a href="{{ base }}/c/{{ running_cycle.id }}" data-testid="running-banner"
      class="flex items-center gap-3 border border-honey/40 bg-honey-wash rounded-lg px-5 py-4 hover:border-honey focus-visible:outline-2 focus-visible:outline-honey">
     <span class="w-2 h-2 rounded-full bg-honey swarm-working" aria-hidden="true"></span>
     <span class="text-sm font-medium">
@@ -56,7 +56,7 @@
           <span class="font-mono text-[13px] text-faint shrink-0 w-12">#{{ issue.number }}</span>
           <p class="text-[15px] min-w-0 truncate flex-1">{{ issue.title }}</p>
           {% if issue.building %}
-          <a href="{{ base }}/cycles/{{ issue.cycle_id }}" class="flex items-center gap-2 text-[13px] font-semibold text-honey-deep shrink-0 focus-visible:outline-2 focus-visible:outline-honey">
+          <a href="{{ base }}/c/{{ issue.cycle_id }}" class="flex items-center gap-2 text-[13px] font-semibold text-honey-deep shrink-0 focus-visible:outline-2 focus-visible:outline-honey">
             <span class="w-1.5 h-1.5 rounded-full bg-honey swarm-working" aria-hidden="true"></span>Follow →
           </a>
           {% else %}

--- a/src/theswarm/presentation/web/templates/v2/theater.html
+++ b/src/theswarm/presentation/web/templates/v2/theater.html
@@ -1,0 +1,87 @@
+{% extends "v2/base.html" %}
+{% block title %}Cycle {{ record.id[:8] }} — TheSwarm{% endblock %}
+{% block content %}
+<div class="flex flex-col gap-6">
+
+  <div class="flex items-start justify-between gap-4 flex-wrap">
+    <div class="min-w-0">
+      <a href="{{ base }}/r/{{ record.repo }}" class="font-mono text-[11px] uppercase tracking-[0.14em] text-faint hover:text-soft focus-visible:outline-2 focus-visible:outline-honey">← {{ record.repo }}</a>
+      <h1 class="text-[22px] font-semibold tracking-tight mt-2 text-balance">
+        {% if pinned.issue %}<span class="font-mono text-faint font-normal">#{{ pinned.issue.number }}</span> {{ pinned.issue.title }}
+        {% elif record.issue_number %}Issue <span class="font-mono">#{{ record.issue_number }}</span>
+        {% else %}{{ record.description or "Cycle" }}{% endif %}
+      </h1>
+    </div>
+    <div class="flex items-center gap-3 shrink-0 pt-1">
+      <span id="status-pill" data-status="{{ record.status.value }}"
+        class="font-mono text-[11px] uppercase tracking-[0.1em] rounded-full px-3 py-1 border
+        {% if record.status.value == 'running' %}border-honey/50 text-honey-deep bg-honey-wash
+        {% elif record.status.value == 'completed' %}border-moss/50 text-moss bg-moss-wash
+        {% elif record.status.value == 'failed' %}border-rust/50 text-rust bg-rust-wash
+        {% else %}border-rule text-soft bg-panel{% endif %}">
+        {{ record.status.value }}</span>
+      <a href="{{ base }}/cycles/{{ record.id }}" class="font-mono text-[11px] text-faint hover:text-soft focus-visible:outline-2 focus-visible:outline-honey">details ↗</a>
+    </div>
+  </div>
+
+  <div id="stage">{% include "v2/_stage.html" %}</div>
+</div>
+
+<script>
+(function () {
+  var stage = document.getElementById("stage");
+  var filter = null;
+
+  function applyFilter() {
+    var note = document.getElementById("feed-filter-note");
+    stage.querySelectorAll(".feed-entry").forEach(function (row) {
+      row.style.display = (!filter || row.dataset.agent === filter) ? "" : "none";
+    });
+    stage.querySelectorAll(".station").forEach(function (b) {
+      b.classList.toggle("ring-2", filter === b.dataset.role);
+      b.classList.toggle("ring-honey", filter === b.dataset.role);
+    });
+    if (note) note.textContent = filter ? "— " + filter + " only (click again to clear)" : "";
+  }
+
+  stage.addEventListener("click", function (event) {
+    var station = event.target.closest(".station");
+    if (!station) return;
+    filter = (filter === station.dataset.role) ? null : station.dataset.role;
+    applyFilter();
+  });
+
+  var FINAL = ["completed", "failed", "cancelled"];
+  var lastHtml = null;
+  function tick() {
+    var inner = document.getElementById("stage-inner");
+    if (inner && FINAL.indexOf(inner.dataset.status) !== -1) return;
+    fetch("{{ base }}/c/{{ record.id }}/stage", {headers: {"Accept": "text/html"}})
+      .then(function (r) { return r.ok ? r.text() : null; })
+      .then(function (html) {
+        // Swap only on real change: a blind 3s innerHTML replace destroys
+        // focus, text selection and the feed's scroll position.
+        if (html && lastHtml === null) {
+          // First poll: the page was just server-rendered with the same
+          // data — seed the baseline without a destructive swap. A change
+          // in this window is caught by the next poll.
+          lastHtml = html;
+        } else if (html && html !== lastHtml) {
+          lastHtml = html;
+          var feed = stage.querySelector('[data-testid="feed"]');
+          var scrollTop = feed ? feed.scrollTop : 0;
+          stage.innerHTML = html;
+          applyFilter();
+          var fresh = stage.querySelector('[data-testid="feed"]');
+          if (fresh) fresh.scrollTop = scrollTop;
+        }
+        var now = document.getElementById("stage-inner");
+        if (!now || FINAL.indexOf(now.dataset.status) === -1) setTimeout(tick, 3000);
+        else window.location.reload();
+      })
+      .catch(function () { setTimeout(tick, 6000); });
+  }
+  setTimeout(tick, 3000);
+})();
+</script>
+{% endblock %}

--- a/tests/presentation/test_v2_flow.py
+++ b/tests/presentation/test_v2_flow.py
@@ -218,7 +218,7 @@ async def test_play_starts_a_cycle_pinned_to_the_issue(web, _isolate_cycle_track
         await asyncio.sleep(0)  # let the created task reach the mock
 
     assert r.status_code == 303
-    assert r.headers["location"].startswith("/swarm/cycles/")
+    assert r.headers["location"].startswith("/swarm/c/")
     cycle_id = r.headers["location"].rsplit("/", 1)[-1]
     record = _isolate_cycle_tracker.get(cycle_id)
     assert record is not None
@@ -241,6 +241,6 @@ async def test_running_cycle_shows_the_follow_banner(web, _isolate_cycle_tracker
         r = await client.get("/r/jrechet/concert-tour-app")
 
     assert 'data-testid="running-banner"' in r.text
-    assert f"/swarm/cycles/{record.id}" in r.text
+    assert f"/swarm/c/{record.id}" in r.text
     assert "Follow" in r.text
     assert "▶" not in r.text  # the building issue offers Follow, not Play

--- a/tests/presentation/test_v2_theater.py
+++ b/tests/presentation/test_v2_theater.py
@@ -1,0 +1,178 @@
+"""The theater: four stations, a pinned issue, a live feed."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from theswarm.application.events.bus import EventBus
+from theswarm.application.services import progress_bridge
+from theswarm.infrastructure.persistence.sqlite_repos import (
+    SQLiteCycleRepository,
+    SQLiteProjectRepository,
+    init_db,
+)
+from theswarm.presentation.web.app import create_web_app
+from theswarm.presentation.web.routes.v2 import _stations
+from theswarm.presentation.web.sse import SSEHub
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tracker_and_progress():
+    from theswarm.api import get_cycle_tracker
+
+    tracker = get_cycle_tracker()
+    before = dict(tracker._cycles)
+    progress_before = dict(progress_bridge._LIVE_PROGRESS)
+    yield tracker
+    tracker._cycles.clear()
+    tracker._cycles.update(before)
+    progress_bridge._LIVE_PROGRESS.clear()
+    progress_bridge._LIVE_PROGRESS.update(progress_before)
+
+
+@pytest.fixture()
+async def web(tmp_path):
+    conn = await init_db(str(tmp_path / "test.db"))
+    app = create_web_app(
+        SQLiteProjectRepository(conn), SQLiteCycleRepository(conn),
+        EventBus(), SSEHub(), base_path="/swarm", db=conn,
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c, app
+    await conn.close()
+
+
+def _record(status="running", issue=21):
+    from theswarm.api import CycleRequest, CycleStatus, get_cycle_tracker
+
+    tracker = get_cycle_tracker()
+    record = tracker.create(
+        CycleRequest(repo="jrechet/concert-tour-app", issue_number=issue),
+    )
+    tracker.update_status(record.id, CycleStatus(status))
+    return tracker.get(record.id)
+
+
+def _rec(status):
+    from theswarm.api import CycleStatus
+
+    return SimpleNamespace(status=CycleStatus(status))
+
+
+# ── Station states from live progress ──────────────────────────────────
+
+
+def test_freshest_role_is_the_active_station():
+    progress = [  # most recent first — the bridge's contract
+        {"role": "dev", "message": "Implementing the waiting list model"},
+        {"role": "techlead", "message": "Split into 3 tasks"},
+        {"role": "po", "message": "Shaped #21"},
+    ]
+    states = {s["key"]: s["state"] for s in _stations(_rec("running"), progress)}
+    assert states == {
+        "po": "done", "techlead": "done", "dev": "active", "qa": "waiting",
+    }
+
+
+def test_running_with_no_progress_yet_lights_the_po():
+    states = {s["key"]: s["state"] for s in _stations(_rec("running"), [])}
+    assert states["po"] == "active"
+    assert states["qa"] == "waiting"
+
+
+def test_completed_cycle_marks_every_station_done():
+    states = {s["key"]: s["state"] for s in _stations(_rec("completed"), [])}
+    assert set(states.values()) == {"done"}
+
+
+def test_failure_lands_on_the_active_station():
+    progress = [{"role": "qa", "message": "Running the e2e suite"}]
+    states = {s["key"]: s["state"] for s in _stations(_rec("failed"), progress)}
+    assert states == {
+        "po": "done", "techlead": "done", "dev": "done", "qa": "failed",
+    }
+
+
+def test_station_carries_its_last_message():
+    progress = [{"role": "dev", "message": "Writing tests for the model"}]
+    stations = {s["key"]: s for s in _stations(_rec("running"), progress)}
+    assert stations["dev"]["message"] == "Writing tests for the model"
+
+
+# ── The page ───────────────────────────────────────────────────────────
+
+
+async def test_theater_renders_rail_issue_and_feed(web):
+    client, _ = web
+    record = _record()
+    progress_bridge.record_live_progress(record.id, "dev", "Implementing #22")
+
+    pinned_issue = {"number": 21, "title": "Fans can join a waiting list"}
+    children = [
+        {"number": 22, "title": "Waiting list model", "labels": ["status:in-progress"],
+         "body": "Parent: #21"},
+        {"number": 23, "title": "Notify on freed seat", "labels": ["status:review"],
+         "body": "Parent: #21"},
+    ]
+    with patch("theswarm.tools.github.GitHubClient") as klass:
+        klass.return_value.get_issue = AsyncMock(return_value=pinned_issue)
+        klass.return_value.get_issues = AsyncMock(return_value=children)
+        r = await client.get(f"/c/{record.id}")
+
+    assert r.status_code == 200
+    assert 'data-testid="agent-rail"' in r.text
+    assert "Fans can join a waiting list" in r.text
+    assert "1/2 done" in r.text
+    assert 'data-state="active"' in r.text
+    assert "Implementing #22" in r.text
+
+
+async def test_stage_fragment_carries_the_status_for_the_poll_loop(web):
+    client, _ = web
+    record = _record(status="running")
+    with patch("theswarm.tools.github.GitHubClient") as klass:
+        klass.return_value.get_issue = AsyncMock(return_value=None)
+        r = await client.get(f"/c/{record.id}/stage")
+
+    assert r.status_code == 200
+    assert 'data-status="running"' in r.text
+
+
+async def test_unknown_cycle_is_a_404(web):
+    client, _ = web
+    r = await client.get("/c/does-not-exist")
+    assert r.status_code == 404
+
+
+async def test_historical_cycle_redirects_to_the_archive_view(web):
+    client, app = web
+    from datetime import datetime, timezone
+
+    from theswarm.domain.cycles.entities import Cycle
+    from theswarm.domain.cycles.value_objects import CycleId, CycleStatus
+
+    cycle = Cycle(
+        id=CycleId("cafe1234cafe"), project_id="p", status=CycleStatus.COMPLETED,
+        triggered_by="test", started_at=datetime.now(timezone.utc),
+    )
+    await app.state.cycle_repo.save(cycle)
+
+    r = await client.get("/c/cafe1234cafe")
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/swarm/cycles/cafe1234cafe"
+
+
+async def test_play_now_lands_on_the_theater(web):
+    client, _ = web
+    with patch("theswarm.api.run_api_cycle", new=AsyncMock()):
+        r = await client.post("/r/jrechet/concert-tour-app/issues/7/play")
+
+    assert r.status_code == 303
+    assert "/swarm/c/" in r.headers["location"]
+    assert "/cycles/" not in r.headers["location"]


### PR DESCRIPTION
Étape 4 (last) of docs/plans/2026-09-v2-one-flow.md. `▶ Play` now lands on `/c/{cycle_id}` — the live view.

## What it shows
- **Four stations on a rail** — PO → TechLead → Dev → QA. The freshest ProgressBridge role is *active* (honey, pulsing) with its latest message under the name; earlier stations show ✓, later ones wait; on failure the ✕ lands on the station that was working.
- **The pinned issue and its breakdown** — shared loader extracted to `application/services/pinned_issue.py` (V1 fragment refactored onto it, its 7 tests untouched); per-child status dots, `x/n done`.
- **Activity feed** — thoughts vs steps from the cycle event store, timestamped, agent-glyphed. **Click a station to filter the feed to that agent**; click again to clear. (Deeper log UX stays a separate feature, as agreed.)
- 3 s poll that only swaps the DOM when the HTML actually changed — a blind swap destroys focus/selection/scroll (found by driving the page in a real browser). Stops on final status. Historical cycles 303 to the V1 archive page.

## Verified
10 new tests (station mapping, page render, fragment status, archive redirect, Play landing); suite 2363 green; smoke green; driven in a real browser against a stubbed live cycle (screenshots in session — desktop + mobile 2×2 grid, light + dark).