### PR TITLE
fix(ci): a daily plan must not redeploy the service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,15 @@ name: CI
 on:
   push:
     branches: [main]
+    # The PO agent commits docs/daily-plans/<date>.md straight to main every
+    # morning. That push used to redeploy the service, replacing the
+    # container and wiping the in-memory cycle tracker — so a cycle running
+    # against theswarm itself killed itself the moment its own PO phase
+    # wrote the plan (observed 2026-09-07: cycle e80598e4bc4a died 40s into
+    # the TechLead phase). A daily plan changes no behaviour: nothing to
+    # test, nothing to deploy.
+    paths-ignore:
+      - 'docs/daily-plans/**'
   pull_request:
     branches: [main]
 

--- a/tests/test_deploy_trigger_guard.py
+++ b/tests/test_deploy_trigger_guard.py
@@ -1,0 +1,40 @@
+"""A daily plan must never redeploy the service.
+
+The PO agent writes docs/daily-plans/<date>.md directly to main. Because
+every push to main deploys, that commit replaced the container and wiped the
+in-memory cycle tracker: a cycle running against theswarm itself died as
+soon as its own PO phase committed the plan it had just written
+(prod cycle e80598e4bc4a, 2026-09-07 — PO ok, killed 40s into TechLead).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+CI = yaml.safe_load(Path(".github/workflows/ci.yml").read_text())
+# PyYAML parses the bare key `on:` as the boolean True.
+TRIGGERS = CI.get("on") or CI.get(True)
+
+
+def test_daily_plans_do_not_trigger_the_pipeline():
+    assert "docs/daily-plans/**" in TRIGGERS["push"]["paths-ignore"]
+
+
+def test_pushes_to_main_still_deploy_everything_else():
+    """The guard must be a path filter, not a disabled trigger."""
+    assert TRIGGERS["push"]["branches"] == ["main"]
+    ignored = TRIGGERS["push"]["paths-ignore"]
+    assert "src/**" not in ignored and "**" not in ignored
+
+
+def test_pull_requests_are_never_path_filtered():
+    """Every PR runs the full suite, whatever it touches."""
+    assert "paths-ignore" not in TRIGGERS["pull_request"]
+
+
+def test_the_po_still_writes_the_plan_where_the_filter_expects_it():
+    """If the PO's path moves, the filter silently stops working."""
+    po = Path("src/theswarm/agents/po.py").read_text()
+    assert 'f"docs/daily-plans/{today}.md"' in po


### PR DESCRIPTION
**A cycle run against theswarm killed itself.** The PO agent writes `docs/daily-plans/<date>.md` directly to `main`; every push to `main` deploys; the deploy replaces the container; the container holds the cycle tracker in memory. So the cycle's own PO phase committed the plan that destroyed the cycle.

Observed twice this morning in prod:
- `ab47422deb24` — lost outright
- `e80598e4bc4a` — PO ✓, TechLead started 05:27:21, dead 05:28:23, to a `PO: daily plan for 2026-09-07` push

Neither was a健康 failure: `exit 137`, `oom=false`, memory 100 MiB / 2 GiB, healthcheck 3/3 green. Purely the redeploy.

## Fix
`paths-ignore: ['docs/daily-plans/**']` on the `push` trigger. A daily plan changes no behaviour — nothing to test, nothing to deploy. Pull requests keep running the full suite whatever they touch (no path filter there).

## Tests
4 new (`test_deploy_trigger_guard.py`), including one that fails if the PO's write path ever moves away from `docs/daily-plans/` and silently defeats the filter. Suite 2378 green.

## Still open, deliberately not in this PR
Any *real* deploy still kills running cycles — the tracker is in-memory (#5). This PR only removes the pathological self-destruct; surviving deploys needs the checkpoint/resume work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)