### PR TITLE
fix(claude): a retried timeout must get more room than the attempt that timed out

### DIFF
--- a/src/theswarm/agents/po.py
+++ b/src/theswarm/agents/po.py
@@ -17,6 +17,9 @@ from theswarm.config import AgentState, Phase, Role
 
 log = logging.getLogger(__name__)
 
+# Same reason as the TechLead breakdown: sized for sonnet, run on opus.
+PLANNING_TIMEOUT_SECONDS = 180
+
 MAX_DAILY_STORIES = 3  # pick at most 3 US per day
 
 
@@ -114,7 +117,7 @@ async def select_daily_issues(state: AgentState) -> dict:
         max_stories=MAX_DAILY_STORIES,
     )
 
-    result = await claude.run(prompt, workdir=state.get("workspace"), timeout=120)
+    result = await claude.run(prompt, workdir=state.get("workspace"), timeout=PLANNING_TIMEOUT_SECONDS)
 
     # Parse Claude's response
     selected = []
@@ -202,7 +205,7 @@ async def validate_demo(state: AgentState) -> dict:
         demo_report=report_text,
     )
 
-    result = await claude.run(prompt, workdir=state.get("workspace"), timeout=120)
+    result = await claude.run(prompt, workdir=state.get("workspace"), timeout=PLANNING_TIMEOUT_SECONDS)
 
     return {
         "daily_report": result.text,

--- a/src/theswarm/agents/techlead.py
+++ b/src/theswarm/agents/techlead.py
@@ -16,6 +16,12 @@ from theswarm.config import AgentState, Role
 
 log = logging.getLogger(__name__)
 
+# Breaking a feature into sub-issues reads the repo and reasons about it;
+# 120s was sized for sonnet and is not enough on opus, which is what the
+# CLI actually runs here. Fits inside PHASE_TIMEOUTS["techlead_breakdown"]
+# together with one grown retry.
+BREAKDOWN_TIMEOUT_SECONDS = 240
+
 
 # ── Prompts ─────────────────────────────────────────────────────────────
 
@@ -167,7 +173,7 @@ async def breakdown_stories(state: AgentState) -> dict:
             issue_body=issue.get("body", "(no description)"),
         )
 
-        result = await claude.run(prompt, timeout=120)
+        result = await claude.run(prompt, timeout=BREAKDOWN_TIMEOUT_SECONDS)
         total_tokens += result.total_tokens
         total_cost += result.cost_usd
 

--- a/src/theswarm/cycle.py
+++ b/src/theswarm/cycle.py
@@ -29,8 +29,11 @@ MAX_DAILY_STORIES = 3  # imported by PO but defined here for reference
 # The old 8-minute cap was sized for the 180s-per-call era and killed every
 # substantial task mid-flight during the endurance run.
 PHASE_TIMEOUTS = {
-    "po_morning": 5 * 60,
-    "techlead_breakdown": 5 * 60,
+    # Each budget must hold one Claude call plus its grown retry (a retried
+    # timeout gets timeout_growth× more room), otherwise the phase timeout
+    # fires first and hides the real cause.
+    "po_morning": 8 * 60,
+    "techlead_breakdown": 10 * 60,
     "dev_iter": 25 * 60,
     "techlead_review": 5 * 60,
     "qa": 15 * 60,

--- a/src/theswarm/tools/claude.py
+++ b/src/theswarm/tools/claude.py
@@ -101,6 +101,10 @@ def _estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
     return inp + out
 
 
+def _is_timeout(error: Exception) -> bool:
+    return "timed out after" in str(error).lower()
+
+
 _AUTH_FAILURE_MARKERS = (
     "oauth", "authenticate", "401", "not logged in", "invalid api key",
 )
@@ -252,7 +256,10 @@ class ClaudeCLI:
                 first_error,
             )
             try:
-                return await self._run_cli(prompt, workdir=workdir, timeout=timeout)
+                return await self._run_cli(
+                    prompt, workdir=workdir,
+                    timeout=self._retry_timeout(timeout, first_error),
+                )
             except _CLIUnavailable as retry_error:
                 raise RuntimeError(
                     "Claude CLI failed twice and no usable API credential is "
@@ -262,6 +269,24 @@ class ClaudeCLI:
 
         log.warning("Claude CLI unavailable (%s) — falling back to API", first_error)
         return await self._run_api(prompt, workdir=workdir, timeout=timeout)
+
+    def _retry_timeout(self, timeout: int | None, error: Exception) -> int:
+        """Give a retry more room than the attempt that ran out of it.
+
+        Retrying a timeout with the same budget cannot succeed: the second
+        attempt does the same work under the same clock. Prod cycle
+        11e5fe09535f died exactly that way — the TechLead breakdown hit its
+        120s twice in a row and the cycle failed with no useful diagnosis.
+        Only timeouts grow; a crash or an auth failure keeps its budget.
+        """
+        effective = timeout or self.timeout
+        if not _is_timeout(error):
+            return effective
+        grown = int(effective * self.timeout_growth)
+        log.warning(
+            "Claude CLI timed out at %ds — retrying with %ds", effective, grown,
+        )
+        return grown
 
     async def _run_cli(
         self,

--- a/tests/test_claude_timeout_retry.py
+++ b/tests/test_claude_timeout_retry.py
@@ -1,0 +1,93 @@
+"""A retried timeout must get more room than the attempt that ran out.
+
+Prod cycle 11e5fe09535f: the TechLead breakdown hit its 120s budget, was
+retried with the same 120s, hit it again, and the cycle failed with
+"Claude CLI failed twice". The second attempt did identical work under an
+identical clock — it never had a chance.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from theswarm.tools.claude import ClaudeCLI, ClaudeResult, _CLIUnavailable, _is_timeout
+
+
+@pytest.fixture(autouse=True)
+def _cli_only_no_api(monkeypatch):
+    monkeypatch.delenv("SWARM_CLAUDE_BACKEND", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+
+@pytest.mark.parametrize("message, expected", [
+    ("CLI timed out after 120s", True),
+    ("cli TIMED OUT AFTER 240s", True),
+    ("exit 1: OAuth access token has expired.", False),
+    ("JSON parse failed", False),
+])
+def test_timeout_detection(message, expected):
+    assert _is_timeout(_CLIUnavailable(message)) is expected
+
+
+async def test_a_timeout_retry_gets_more_room():
+    cli = ClaudeCLI(model="haiku", timeout=120, timeout_growth=1.3)
+    seen: list[int | None] = []
+
+    async def timing_out(prompt, *, workdir, timeout, drop_oauth_env=False):
+        seen.append(timeout)
+        if len(seen) == 1:
+            raise _CLIUnavailable("CLI timed out after 120s")
+        return ClaudeResult(text="recovered", backend="cli")
+
+    with patch.object(cli, "_run_cli", side_effect=timing_out):
+        result = await cli.run("hi")
+
+    assert result.text == "recovered"
+    assert seen == [None, 156]  # 120 × 1.3 — the retry can actually finish
+
+
+async def test_an_explicit_call_budget_grows_from_that_budget():
+    """Agents pass their own timeout; the retry must grow *that* number."""
+    cli = ClaudeCLI(model="haiku", timeout=180, timeout_growth=1.3)
+    seen: list[int | None] = []
+
+    async def timing_out(prompt, *, workdir, timeout, drop_oauth_env=False):
+        seen.append(timeout)
+        if len(seen) == 1:
+            raise _CLIUnavailable("CLI timed out after 240s")
+        return ClaudeResult(text="ok", backend="cli")
+
+    with patch.object(cli, "_run_cli", side_effect=timing_out):
+        await cli.run("hi", timeout=240)
+
+    assert seen == [240, 312]
+
+
+async def test_a_non_timeout_failure_keeps_its_budget():
+    """Growing the clock only helps a timeout; a crash retries as before."""
+    cli = ClaudeCLI(model="haiku", timeout=120)
+    seen: list[int | None] = []
+
+    async def crashing(prompt, *, workdir, timeout, drop_oauth_env=False):
+        seen.append(timeout)
+        raise _CLIUnavailable("JSON parse failed")
+
+    with patch.object(cli, "_run_cli", side_effect=crashing):
+        with pytest.raises(RuntimeError):
+            await cli.run("hi", timeout=90)
+
+    assert seen == [90, 90]
+
+
+async def test_both_attempts_timing_out_still_reports_the_real_cause():
+    cli = ClaudeCLI(model="haiku", timeout=120)
+
+    async def always_timeout(prompt, *, workdir, timeout, drop_oauth_env=False):
+        raise _CLIUnavailable(f"CLI timed out after {timeout or 120}s")
+
+    with patch.object(cli, "_run_cli", side_effect=always_timeout):
+        with pytest.raises(RuntimeError, match="timed out after 156s"):
+            await cli.run("hi")

--- a/tests/test_phase_budget_headroom.py
+++ b/tests/test_phase_budget_headroom.py
@@ -1,0 +1,32 @@
+"""A phase must outlast the Claude call it wraps, plus that call's retry.
+
+If the phase timeout fires first, the cycle reports "phase timed out" and
+the real cause (the model needed more room) is lost.
+"""
+
+from __future__ import annotations
+
+from theswarm.agents.po import PLANNING_TIMEOUT_SECONDS
+from theswarm.agents.techlead import BREAKDOWN_TIMEOUT_SECONDS
+from theswarm.cycle import PHASE_TIMEOUTS
+from theswarm.tools.claude import ClaudeCLI
+
+GROWTH = ClaudeCLI.timeout_growth
+
+
+def _attempt_plus_retry(call_budget: int) -> float:
+    return call_budget + call_budget * GROWTH
+
+
+def test_techlead_breakdown_phase_holds_attempt_and_retry():
+    assert _attempt_plus_retry(BREAKDOWN_TIMEOUT_SECONDS) < PHASE_TIMEOUTS["techlead_breakdown"]
+
+
+def test_po_morning_phase_holds_attempt_and_retry():
+    assert _attempt_plus_retry(PLANNING_TIMEOUT_SECONDS) < PHASE_TIMEOUTS["po_morning"]
+
+
+def test_budgets_are_above_what_actually_timed_out_in_prod():
+    """120s was the value that failed twice on cycle 11e5fe09535f."""
+    assert BREAKDOWN_TIMEOUT_SECONDS > 120
+    assert PLANNING_TIMEOUT_SECONDS > 120


### PR DESCRIPTION
Prod cycle `11e5fe09535f` (on #46) reached TechLead and died with `Claude CLI failed twice … CLI timed out after 120s`.

**The retry never had a chance.** The CLI path retried with *the same* 120s budget: same work, same clock, same outcome. (The API fallback path already grew its timeout on retry; the CLI path didn't.)

## Fix
- `_retry_timeout()` — a **timeout** retry grows by `timeout_growth` (120 → 156s). A crash or an auth failure keeps its budget, since more time wouldn't help.
- The `timeout=120` call budgets were sized when the CLI ran **sonnet**; it runs **opus** here. TechLead breakdown 120 → **240s**, PO planning 120 → **180s**, both now named constants instead of bare literals.
- `PHASE_TIMEOUTS` must hold one attempt **plus its grown retry**, otherwise the phase timeout fires first and reports "phase timed out" while hiding the real cause: `po_morning` 5 → 8 min, `techlead_breakdown` 5 → 10 min.

## Tests
11 new. `test_phase_budget_headroom.py` pins the attempt+retry < phase-budget relationship, so changing any one of those numbers in isolation fails the suite. Full suite **2389 green**, e2e smoke green.

## Context
Second fix in the chain that made cycles unusable — [#47](https://github.com/jrechet/theswarm/pull/47) stopped the daily-plan commit from redeploying and killing them mid-flight; this one stops the survivors from failing on a budget that was never realistic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)