### PR TITLE
fix(git): a failed iteration must not poison every later one

### DIFF
--- a/src/theswarm/tools/git.py
+++ b/src/theswarm/tools/git.py
@@ -125,6 +125,17 @@ async def create_branch(workdir: str, branch_name: str, base: str = "main") -> N
     off base anyway, which is exactly what resetting gives.
     """
     await github_app.ensure_github_token()
+    # The workspace is reused across iterations, so a half-finished attempt
+    # leaves modified files behind and `git checkout main` then refuses with
+    # "Your local changes would be overwritten". That is not recoverable on
+    # its own: every later iteration hits the same wall, so one bad attempt
+    # burned the whole Dev phase and the cycle opened no PR at all (prod
+    # cycle 6ecb297eae40 — five iterations, five identical failures).
+    # Discarding is safe precisely because the next line resets the branch to
+    # `base`: anything uncommitted here is either already pushed or is debris.
+    # `clean -fd` honours .gitignore, so the venv and caches survive.
+    await _run_git("reset", "--hard", cwd=workdir, check=False)
+    await _run_git("clean", "-fd", cwd=workdir, check=False)
     await _run_git("checkout", base, cwd=workdir)
     await _run_git(*_auth_args(), "pull", "--ff-only", cwd=workdir, check=False)
     await _run_git("checkout", "-B", branch_name, cwd=workdir)

--- a/tests/test_dev_workspace_recovery.py
+++ b/tests/test_dev_workspace_recovery.py
@@ -1,0 +1,77 @@
+"""A dirty workspace must not poison every later iteration.
+
+Prod cycle 6ecb297eae40: an implementation attempt left modified files in
+the reused workspace; `git checkout main` then refused, and because the
+workspace is never cleaned, all five Dev iterations failed the same way and
+the cycle finished having opened no PR.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from theswarm.tools.git import create_branch
+
+
+@pytest.fixture()
+def git_calls():
+    calls: list[tuple[str, ...]] = []
+
+    async def record(*args, **kwargs):
+        calls.append(args)
+        return ""
+
+    with patch("theswarm.tools.git._run_git", side_effect=record), \
+         patch("theswarm.tools.git.github_app.ensure_github_token",
+               new=AsyncMock(return_value="")):
+        yield calls
+
+
+def _verbs(calls):
+    return [next((a for a in c if not a.startswith("-")), "") for c in calls]
+
+
+async def test_workspace_is_cleared_before_switching_branches(git_calls):
+    await create_branch("/w", "feat/issue-49")
+    verbs = _verbs(git_calls)
+    assert verbs.index("reset") < verbs.index("checkout")
+    assert verbs.index("clean") < verbs.index("checkout")
+
+
+async def test_tracked_changes_are_discarded_hard(git_calls):
+    await create_branch("/w", "feat/issue-49")
+    assert ("reset", "--hard") in git_calls
+
+
+async def test_untracked_files_are_removed_but_ignored_ones_survive(git_calls):
+    """`clean -fd` without -x: the venv and caches must not be wiped."""
+    await create_branch("/w", "feat/issue-49")
+    assert ("clean", "-fd") in git_calls
+    assert not any("-x" in c for c in git_calls if c and c[0] == "clean")
+
+
+async def test_cleanup_never_aborts_the_branch_creation():
+    """A fresh clone has nothing to reset; that must not fail the phase."""
+    seen: list[dict] = []
+
+    async def record(*args, **kwargs):
+        seen.append({"args": args, "check": kwargs.get("check", True)})
+        return ""
+
+    with patch("theswarm.tools.git._run_git", side_effect=record), \
+         patch("theswarm.tools.git.github_app.ensure_github_token",
+               new=AsyncMock(return_value="")):
+        await create_branch("/w", "feat/issue-49")
+
+    for call in seen:
+        if call["args"][:1] in (("reset",), ("clean",)):
+            assert call["check"] is False
+
+
+async def test_the_branch_is_still_reset_onto_base(git_calls):
+    """The cleanup must not change what create_branch is for."""
+    await create_branch("/w", "feat/issue-49", base="main")
+    assert ("checkout", "main") in git_calls
+    assert ("checkout", "-B", "feat/issue-49") in git_calls

--- a/tests/test_tools_git.py
+++ b/tests/test_tools_git.py
@@ -82,15 +82,19 @@ async def test_create_branch(mock_subprocess):
     await create_branch("/tmp/repo", "feat/new", base="main")
     import asyncio
     calls = asyncio.create_subprocess_exec.call_args_list
-    # Expect: checkout main, pull, checkout -b feat/new
-    assert len(calls) == 3
-    assert calls[0].args[1] == "checkout"
-    assert calls[0].args[2] == "main"
+    # Expect: reset --hard, clean -fd, checkout main, pull, checkout -B feat/new.
+    # The reset+clean pair leads because a previous iteration's leftovers make
+    # `checkout main` refuse outright (see test_dev_workspace_recovery.py).
+    assert len(calls) == 5
+    assert calls[0].args[1] == "reset"
+    assert calls[1].args[1] == "clean"
     assert calls[2].args[1] == "checkout"
+    assert calls[2].args[2] == "main"
+    assert calls[4].args[1] == "checkout"
     # -B, not -b: the workspace is reused across dev iterations, so a retried
     # task derives the same branch name and -b would fail rc=128.
-    assert calls[2].args[2] == "-B"
-    assert calls[2].args[3] == "feat/new"
+    assert calls[4].args[2] == "-B"
+    assert calls[4].args[3] == "feat/new"
 
 
 # ── commit_all ─────────────────────────────────────────────────────────


### PR DESCRIPTION
**This is why cycles open no PR.** Prod cycle `6ecb297eae40` ran the whole pipeline — PO ✓, TechLead split #46 into four sub-issues (#49–#52) ✓, Dev ran 67 minutes — and produced nothing. All five Dev iterations failed identically:

```
git checkout main failed (rc=1): error: Your local changes to the
following files would be overwritten by checkout
Please commit your changes or stash them before you switch branches.
```

The workspace is reused across iterations. The first half-finished attempt left modified files behind; `git checkout main` refused from then on; nothing ever cleans it. So **one bad attempt burns the entire Dev phase** — and the cycle still reports `completed`. That is exactly the shape of April's "9 cycles, 0 PRs merged".

## Fix
`create_branch()` discards the workspace before switching:
```
git reset --hard      # tracked changes
git clean -fd         # untracked files, .gitignore honoured → venv/caches survive
git checkout <base>
```
Safe by construction: the very next line resets the branch onto `base`, so anything uncommitted there is either already pushed or is debris. Both cleanup commands run with `check=False` — a fresh clone has nothing to reset and must not fail the phase.

## Tests
5 new (`test_dev_workspace_recovery.py`): ordering, hard reset, `-fd` without `-x`, non-fatal cleanup, and that the branch is still reset onto base. The pre-existing `test_create_branch` is updated to the new call sequence with a comment explaining why the pair leads. Suite **2394 green**, e2e smoke green.

Third in the chain that made cycles unusable: [#47](https://github.com/jrechet/theswarm/pull/47) (self-destruct via daily plan) → [#48](https://github.com/jrechet/theswarm/pull/48) (retry with no extra time) → this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)