### PR TITLE
fix(cycles): at startup every running cycle is an orphan, whatever its age

### DIFF
--- a/src/theswarm/presentation/web/server.py
+++ b/src/theswarm/presentation/web/server.py
@@ -469,10 +469,18 @@ async def start_server(
     bus = EventBus()
 
     # Reap orphan cycles left in 'running' state by a previous container's
-    # background task that died on restart. Marks anything older than 2h
-    # as failed so the dashboard list reflects reality.
+    # background task that died on restart.
+    #
+    # No age cutoff here, deliberately. A cycle is 'running' only while its
+    # in-process task is alive, and at startup no task exists yet — so every
+    # such row belongs to a process that is already dead, whatever its age.
+    # The old 2h cutoff spared exactly the ones that matter: a cycle killed
+    # seconds ago by this very restart kept claiming to run (prod cycle
+    # fc6609d29b32 still said 'running' an hour after the deploy that ended
+    # it). The periodic loop below keeps its cutoff — it runs while cycles
+    # are legitimately in flight.
     try:
-        reaped = await cycle_repo.reap_orphans(max_age_seconds=7200)
+        reaped = await cycle_repo.reap_orphans(max_age_seconds=0)
         if reaped:
             log.info("Reaped %d orphan running cycle(s) on startup", reaped)
     except Exception:

--- a/tests/test_startup_orphan_reap.py
+++ b/tests/test_startup_orphan_reap.py
@@ -1,0 +1,75 @@
+"""At startup, every 'running' cycle is an orphan — whatever its age.
+
+A cycle is 'running' only while its in-process task is alive; at startup no
+task exists yet. The old 2h cutoff therefore spared precisely the cycles a
+restart had just killed: prod cycle fc6609d29b32 still claimed to be running
+an hour after the deploy that ended it, which is what "hung for hours" looked
+like on the dashboard.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from theswarm.domain.cycles.entities import Cycle
+from theswarm.domain.cycles.value_objects import CycleId, CycleStatus
+from theswarm.infrastructure.persistence.sqlite_repos import (
+    SQLiteCycleRepository,
+    init_db,
+)
+
+
+@pytest.fixture()
+async def repo(tmp_path):
+    conn = await init_db(str(tmp_path / "t.db"))
+    yield SQLiteCycleRepository(conn)
+    await conn.close()
+
+
+async def _running(repo, cycle_id: str, age_seconds: int) -> None:
+    await repo.save(Cycle(
+        id=CycleId(cycle_id), project_id="p", status=CycleStatus.RUNNING,
+        triggered_by="test",
+        started_at=datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+    ))
+
+
+async def test_a_cycle_killed_seconds_ago_is_reaped(repo):
+    """The exact case the old cutoff missed."""
+    await _running(repo, "fc6609d29b32", age_seconds=30)
+
+    assert await repo.reap_orphans(max_age_seconds=0) == 1
+
+    cycle = await repo.get(CycleId("fc6609d29b32"))
+    assert cycle.status == CycleStatus.FAILED
+
+
+async def test_old_orphans_are_reaped_too(repo):
+    await _running(repo, "aaaaaaaaaaaa", age_seconds=99_999)
+    assert await repo.reap_orphans(max_age_seconds=0) == 1
+
+
+async def test_finished_cycles_are_untouched(repo):
+    await repo.save(Cycle(
+        id=CycleId("bbbbbbbbbbbb"), project_id="p",
+        status=CycleStatus.COMPLETED, triggered_by="test",
+        started_at=datetime.now(timezone.utc),
+    ))
+    assert await repo.reap_orphans(max_age_seconds=0) == 0
+    cycle = await repo.get(CycleId("bbbbbbbbbbbb"))
+    assert cycle.status == CycleStatus.COMPLETED
+
+
+async def test_the_periodic_loop_keeps_its_age_guard():
+    """Only startup may reap indiscriminately: the loop runs while cycles live."""
+    from theswarm.application.services.orphan_reaper import reap_max_age_seconds
+
+    assert reap_max_age_seconds() > 0
+
+
+def test_startup_passes_no_age_cutoff():
+    source = Path("src/theswarm/presentation/web/server.py").read_text()
+    assert "reap_orphans(max_age_seconds=0)" in source


### PR DESCRIPTION
The startup orphan reap used a 2-hour cutoff — which spared **exactly the cycles that a restart had just killed**. Prod cycle `fc6609d29b32` still said `running` an hour after the deploy that ended it. On the dashboard that is indistinguishable from a cycle hung for hours, which is the symptom that opened this whole investigation.

## Why no cutoff is the correct answer at startup
A cycle is `running` only while its in-process task is alive. At startup **no task exists yet**, so every `running` row belongs to a process that is already dead — whatever its `started_at`. The age check was guarding against nothing and hiding the recent cases.

The **periodic** loop keeps its cutoff (`reap_max_age_seconds()`, above `CYCLE_HARD_TIMEOUT_SECONDS`): it runs while cycles are legitimately in flight, so there the guard is load-bearing. A test pins that asymmetry.

## Tests
5 new, including the exact prod case (a cycle 30 seconds old must be reaped) and a guard that the periodic loop never loses its cutoff. Suite **2399 green**.

Fourth in the chain: [#47](https://github.com/jrechet/theswarm/pull/47) self-destruct → [#48](https://github.com/jrechet/theswarm/pull/48) doomed retry → [#53](https://github.com/jrechet/theswarm/pull/53) poisoned workspace → this one (cycles that lie about being alive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)