### PR TITLE
fix(claude): an exhausted subscription window is fatal, not retryable

### DIFF
--- a/src/theswarm/tools/claude.py
+++ b/src/theswarm/tools/claude.py
@@ -40,6 +40,22 @@ _RETRYABLE_ERRORS: tuple[type[BaseException], ...] = (
 # malformed prompt): every subsequent call in the cycle will fail the same way.
 _FATAL_BAD_REQUEST_MARKERS = ("credit balance", "billing", "plans & billing")
 
+# The CLI reports an exhausted subscription window as a plain exit-1 message.
+# It is a wall with a clock on it, not a hiccup: retrying cannot help until
+# the stated reset. Prod cycle 980dc1e098bc burned its last two Dev
+# iterations and the whole QA phase against it in 30 seconds, then reported
+# a generic "CLI failed twice" that said nothing about quota.
+_QUOTA_MARKERS = ("session limit", "usage limit", "quota exceeded")
+
+
+def _quota_exhausted(error: Exception) -> str | None:
+    """Return the CLI's own wording (which carries the reset time), else None."""
+    message = str(error)
+    lowered = message.lower()
+    if any(marker in lowered for marker in _QUOTA_MARKERS):
+        return message
+    return None
+
 
 class ClaudeFatalError(Exception):
     """Non-retryable Claude failure: billing, auth, or invalid credentials.
@@ -222,6 +238,13 @@ class ClaudeCLI:
             return await self._run_cli(prompt, workdir=workdir, timeout=timeout)
         except _CLIUnavailable as exc:
             first_error = exc
+
+        # Out of subscription window: every later call fails identically until
+        # the reset the CLI names. Abort the cycle now, keeping its wording so
+        # the failure says when work can resume.
+        quota = _quota_exhausted(first_error)
+        if quota is not None:
+            raise ClaudeFatalError(f"Claude subscription exhausted: {quota}")
 
         # A stale CLAUDE_CODE_OAUTH_TOKEN outranks the session on disk, so it
         # breaks every call while ~/.claude still holds valid, self-refreshing

--- a/tests/test_claude_quota_fatal.py
+++ b/tests/test_claude_quota_fatal.py
@@ -1,0 +1,95 @@
+"""An exhausted subscription window is a wall, not a hiccup.
+
+Prod cycle 980dc1e098bc: the CLI returned
+"You've hit your session limit · resets 9:50am (UTC)". Nothing classified
+that as fatal, so the Dev loop burned its last two iterations and the whole
+QA phase against it in 30 seconds and reported "CLI failed twice and no
+usable API credential is available" — which says nothing about quota.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from theswarm.tools.claude import (
+    ClaudeCLI,
+    ClaudeFatalError,
+    _CLIUnavailable,
+    _quota_exhausted,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_api_fallback(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("SWARM_CLAUDE_BACKEND", raising=False)
+
+
+@pytest.mark.parametrize("message", [
+    "exit 1: You've hit your session limit · resets 9:50am (UTC)",
+    "exit 1: usage limit reached",
+    "CLI reported error: quota exceeded",
+])
+def test_quota_messages_are_recognised(message):
+    assert _quota_exhausted(_CLIUnavailable(message)) == message
+
+
+@pytest.mark.parametrize("message", [
+    "CLI timed out after 120s",
+    "exit 1: OAuth access token has expired.",
+    "JSON parse failed",
+])
+def test_other_failures_are_not_quota(message):
+    assert _quota_exhausted(_CLIUnavailable(message)) is None
+
+
+async def test_quota_aborts_immediately_without_retrying():
+    cli = ClaudeCLI(model="haiku")
+    attempts = 0
+
+    async def out_of_quota(prompt, *, workdir, timeout, drop_oauth_env=False):
+        nonlocal attempts
+        attempts += 1
+        raise _CLIUnavailable(
+            "exit 1: You've hit your session limit · resets 9:50am (UTC)",
+        )
+
+    with patch.object(cli, "_run_cli", side_effect=out_of_quota):
+        with pytest.raises(ClaudeFatalError):
+            await cli.run("hi")
+
+    assert attempts == 1  # a wall with a clock on it: retrying cannot help
+
+
+async def test_the_reset_time_survives_into_the_message():
+    """The failure must tell the operator when work can resume."""
+    cli = ClaudeCLI(model="haiku")
+
+    async def out_of_quota(prompt, *, workdir, timeout, drop_oauth_env=False):
+        raise _CLIUnavailable(
+            "exit 1: You've hit your session limit · resets 9:50am (UTC)",
+        )
+
+    with patch.object(cli, "_run_cli", side_effect=out_of_quota):
+        with pytest.raises(ClaudeFatalError, match="resets 9:50am"):
+            await cli.run("hi")
+
+
+async def test_a_timeout_still_gets_its_retry():
+    """Only quota short-circuits; ordinary failures keep the retry path."""
+    cli = ClaudeCLI(model="haiku", timeout=120)
+    attempts = 0
+
+    async def timing_out(prompt, *, workdir, timeout, drop_oauth_env=False):
+        nonlocal attempts
+        attempts += 1
+        raise _CLIUnavailable("CLI timed out after 120s")
+
+    with patch.object(cli, "_run_cli", side_effect=timing_out):
+        with pytest.raises(RuntimeError):
+            await cli.run("hi")
+
+    assert attempts == 2


### PR DESCRIPTION
Prod cycle `980dc1e098bc` — the one that **did** open a PR ([#59](https://github.com/jrechet/theswarm/pull/59), CI green) — then died on:

```
exit 1: You've hit your session limit · resets 9:50am (UTC)
```

Nothing classified that as fatal. So the Dev loop threw its last two iterations **and** the whole QA phase at the wall in 30 seconds (08:21:28 → 08:21:58), each retrying twice, and the cycle finished reporting `Claude CLI failed twice and no usable API credential is available` — which says nothing about quota and sends the reader hunting for a credential bug that does not exist.

## Fix
Quota exhaustion raises `ClaudeFatalError` on the **first** occurrence. The cycle already knows how to abort cleanly on that (`cycle.py:345`), and the CLI's own wording is preserved, so the failure carries the reset time instead of a generic message.

Only quota short-circuits — timeouts and auth failures keep their retry paths, pinned by tests.

## Tests
6 new. Suite **2403 green**, e2e smoke green.

Fifth in the chain: [#47](https://github.com/jrechet/theswarm/pull/47) self-destruct → [#48](https://github.com/jrechet/theswarm/pull/48) doomed retry → [#53](https://github.com/jrechet/theswarm/pull/53) poisoned workspace → [#58](https://github.com/jrechet/theswarm/pull/58) cycles that lie about being alive → this one (quota that reads as a credential bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)