### PR TITLE
fix(claude): recover from a stale env token on every attempt, not just the first

### DIFF
--- a/src/theswarm/tools/claude.py
+++ b/src/theswarm/tools/claude.py
@@ -235,7 +235,9 @@ class ClaudeCLI:
             return await self._run_api(prompt, workdir=workdir, timeout=timeout)
 
         try:
-            return await self._run_cli(prompt, workdir=workdir, timeout=timeout)
+            return await self._cli_with_auth_recovery(
+                prompt, workdir=workdir, timeout=timeout,
+            )
         except _CLIUnavailable as exc:
             first_error = exc
 
@@ -245,23 +247,6 @@ class ClaudeCLI:
         quota = _quota_exhausted(first_error)
         if quota is not None:
             raise ClaudeFatalError(f"Claude subscription exhausted: {quota}")
-
-        # A stale CLAUDE_CODE_OAUTH_TOKEN outranks the session on disk, so it
-        # breaks every call while ~/.claude still holds valid, self-refreshing
-        # credentials — which is exactly what took prod down twice. Drop the
-        # env token and try again before treating this as a real outage.
-        if _is_auth_failure(first_error) and os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
-            log.warning(
-                "Claude CLI auth failed (%s) — retrying without the "
-                "CLAUDE_CODE_OAUTH_TOKEN env override",
-                first_error,
-            )
-            try:
-                return await self._run_cli(
-                    prompt, workdir=workdir, timeout=timeout, drop_oauth_env=True,
-                )
-            except _CLIUnavailable as exc2:
-                first_error = exc2
 
         if backend == "cli":
             raise RuntimeError(
@@ -279,7 +264,7 @@ class ClaudeCLI:
                 first_error,
             )
             try:
-                return await self._run_cli(
+                return await self._cli_with_auth_recovery(
                     prompt, workdir=workdir,
                     timeout=self._retry_timeout(timeout, first_error),
                 )
@@ -292,6 +277,32 @@ class ClaudeCLI:
 
         log.warning("Claude CLI unavailable (%s) — falling back to API", first_error)
         return await self._run_api(prompt, workdir=workdir, timeout=timeout)
+
+    async def _cli_with_auth_recovery(
+        self, prompt: str, *, workdir: str | None, timeout: int | None,
+    ) -> ClaudeResult:
+        """Run the CLI, recovering from a stale env token on any attempt.
+
+        A stale CLAUDE_CODE_OAUTH_TOKEN outranks the session on disk, so it
+        breaks every call while ~/.claude still holds valid, self-refreshing
+        credentials — which took prod down twice. The recovery used to guard
+        only the first attempt, so an auth error surfacing on the *retry* went
+        unhandled: prod cycle c3ab6da6f5d9 timed out, earned its grown retry,
+        and that retry died on an expired token with no second chance.
+        """
+        try:
+            return await self._run_cli(prompt, workdir=workdir, timeout=timeout)
+        except _CLIUnavailable as exc:
+            if not (_is_auth_failure(exc)
+                    and os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")):
+                raise
+            log.warning(
+                "Claude CLI auth failed (%s) — retrying without the "
+                "CLAUDE_CODE_OAUTH_TOKEN env override", exc,
+            )
+            return await self._run_cli(
+                prompt, workdir=workdir, timeout=timeout, drop_oauth_env=True,
+            )
 
     def _retry_timeout(self, timeout: int | None, error: Exception) -> int:
         """Give a retry more room than the attempt that ran out of it.

--- a/tests/test_claude_cli_auth_recovery.py
+++ b/tests/test_claude_cli_auth_recovery.py
@@ -166,3 +166,36 @@ async def test_dropping_the_override_removes_it_from_the_child_env(monkeypatch):
     env = spawn.call_args.kwargs["env"]
     assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
     assert "ANTHROPIC_API_KEY" not in env  # long-standing rule, still enforced
+
+
+# ── The recovery must guard the retry too ──────────────────────────────
+
+
+async def test_auth_failure_on_the_grown_retry_still_recovers(monkeypatch):
+    """Prod cycle c3ab6da6f5d9: the first attempt timed out, earned its grown
+    retry, and that retry died on an expired token. The recovery guarded only
+    the first attempt, so the cycle had no second chance."""
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-stale")
+    monkeypatch.delenv("SWARM_CLAUDE_BACKEND", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    attempts: list[tuple[int | None, bool]] = []
+
+    async def flaky(prompt, *, workdir, timeout, drop_oauth_env=False):
+        attempts.append((timeout, drop_oauth_env))
+        if len(attempts) == 1:
+            raise _CLIUnavailable("CLI timed out after 240s")
+        if not drop_oauth_env:
+            raise _CLIUnavailable(
+                "exit 1: Failed to authenticate. API Error: 401 "
+                "OAuth access token has expired.",
+            )
+        return ClaudeResult(text="recovered", backend="cli")
+
+    cli = ClaudeCLI(model="haiku", timeout=240)
+    with patch.object(cli, "_run_cli", side_effect=flaky):
+        result = await cli.run("hi", timeout=240)
+
+    assert result.text == "recovered"
+    # timed out at 240 → retry at 312 → auth error → same 312 without the token
+    assert attempts == [(240, False), (312, False), (312, True)]


### PR DESCRIPTION
Prod cycle `c3ab6da6f5d9` died in TechLead. The logs show [#48](https://github.com/jrechet/theswarm/pull/48) working exactly as intended:

```
Claude CLI timed out at 240s — retrying with 312s
```

…and then the retry hit `401 OAuth access token has expired`. Minutes later both credential paths tested fine in the container — the token was mid-refresh.

**The recovery guarded only the first attempt.** Dropping `CLAUDE_CODE_OAUTH_TOKEN` (which outranks the self-refreshing `~/.claude` session, and has now taken prod down four times) was tried only on the *first* error. An auth failure surfacing on the retry went unhandled, so the cycle failed on credentials that were working.

## Fix
The recovery moves into `_cli_with_auth_recovery()`, used by **both** the first attempt and the grown retry. A test reproduces the exact prod sequence: `240 timeout → 312 retry → auth error → same 312 without the override`.

Existing auth-recovery tests are unchanged and still pass — the refactor preserves their call semantics.

## Tests
1 new (the prod sequence) on top of the existing 15. Suite **2423 green**, e2e smoke green.

Sixth in the chain: [#47](https://github.com/jrechet/theswarm/pull/47) → [#48](https://github.com/jrechet/theswarm/pull/48) → [#53](https://github.com/jrechet/theswarm/pull/53) → [#58](https://github.com/jrechet/theswarm/pull/58) → [#60](https://github.com/jrechet/theswarm/pull/60) → this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)