### PR TITLE
fix(web): the board's credential handler used an attribute that does not exist

### DIFF
--- a/src/theswarm/presentation/web/routes/projects.py
+++ b/src/theswarm/presentation/web/routes/projects.py
@@ -123,7 +123,7 @@ async def project_issues(request: Request, project_id: str) -> HTMLResponse:
         # instead of surfacing whatever raw error PyGitHub would have given.
         log.warning(
             "No GitHub access for project %s (repo=%s): %s",
-            project_id, exc.repo_name, exc.reason,
+            project_id, exc.repo, exc.reason,
         )
         error = f"No usable GitHub token for '{project.repo}': {exc}"
         credential_error = True


### PR DESCRIPTION
**`main` is currently broken** — two tests fail on it:

```
src/theswarm/presentation/web/routes/projects.py:126: AttributeError
FAILED test_board_reports_missing_github_token
FAILED test_board_distinguishes_no_access_from_missing_token
```

`projects.py` reads `exc.repo_name`; the merged `GitHubAccessError` exposes `.repo`. So the exact code path added to *explain* a credential problem raises `AttributeError` instead, turning a helpful message into a 500.

**This one is mine, not the Dev agent's.** Reviewing [#66](https://github.com/jrechet/theswarm/pull/66) I found the collision (the branch predated [#65](https://github.com/jrechet/theswarm/pull/65) and redefined both symbols with a different API), kept `main`'s implementation, and aligned the handler — then pushed the rebase **without committing that last edit**. CI validated a tree that did not contain the fix, and I merged it. A stop-hook flagged the uncommitted file afterwards, which is how it surfaced.

Suite 2429 green, e2e smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)